### PR TITLE
Fix streaming display bug - messages appear as single bubbles

### DIFF
--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -122,12 +122,40 @@ export interface LearnerState {
 }
 
 // WebSocket message types
-export interface WSMessage {
-  type: "user" | "assistant" | "error" | "status";
+export type WSMessageType = "chunk" | "complete" | "error";
+
+export interface WSChunkMessage {
+  type: "chunk";
   content: string;
-  mode?: DialogueMode;
-  timestamp?: string;
 }
+
+export interface WSCompleteMessage {
+  type: "complete";
+  response: {
+    message: string;
+    mode: string;
+    transition_to: string | null;
+    transition_reason: string | null;
+    gap_identified: {
+      name: string;
+      display_name: string;
+      description: string;
+    } | null;
+    proof_earned: {
+      concept_id: string;
+      demonstration_type: string;
+      evidence: string;
+    } | null;
+    outcome_achieved: boolean;
+  };
+}
+
+export interface WSErrorMessage {
+  type: "error";
+  message: string;
+}
+
+export type WSMessage = WSChunkMessage | WSCompleteMessage | WSErrorMessage;
 
 // Session context types (Set/Setting/Intention)
 export interface SessionContext {


### PR DESCRIPTION
## Summary

Fixes #62 - Chat messages now display as single bubbles instead of individual tokens

**Root cause:** Backend streams raw JSON tokens from LLM's structured output (response_format={"type": "json_object"}), and the frontend was treating each WebSocket message as a new chat bubble.

**Solution:** 
- Added discriminated union types for WebSocket messages (chunk/complete/error)
- Rewrote websocket.ts to dispatch different message types to separate handlers
- Updated useChat.ts to only add messages on "complete" events (chunks now just update typing indicator)
- Fixed chat.py attribute bug: `response.mode` → `response.current_mode`

## Test plan

- [x] Start backend server (`python -m uvicorn src.sage.api.main:app`)
- [x] Start frontend (`cd web && npm run dev`)
- [x] Navigate to `/chat?learner=test-learner`
- [x] Send a message
- [x] Verify SAGE response appears as single bubble with mode badge
- [x] Verify typing indicator shows during streaming

## Screenshots

Messages now display correctly as single bubbles with mode badges:

![streaming-fix-verified](https://github.com/user-attachments/assets/placeholder)