### PR TITLE
feat(api): WebSocket protocol extension for voice/UI parity (#84)

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+started_at: "2026-01-15T21:14:55Z"
+---
+
+Implement ALL remaining issues in Voice/UI Parity epic

--- a/docs/architecture/voice-ui-parity.md
+++ b/docs/architecture/voice-ui-parity.md
@@ -1,0 +1,428 @@
+# Voice/UI Parity Architecture
+
+## Executive Summary
+
+This document presents a comprehensive architecture for achieving complete voice/UI parity in SAGE, ensuring that every interaction available through the graphical user interface is equally accessible via voice conversation, and vice versa.
+
+**Key Use Cases:**
+- **Dog walker**: Voice only, no screen - all features work through conversation
+- **Train commuter**: UI only, can't speak - all features work through forms
+
+## Problem Statement
+
+Currently, SAGE has feature gaps between modalities:
+
+| Feature | UI Support | Voice Support |
+|---------|------------|---------------|
+| Check-in (Set/Setting/Intention) | Modal form | None |
+| Practice Setup | Modal form | None |
+| Chat/Learning | Text input | Full voice I/O |
+| Graph Filters | Filter panel | None |
+| Verification | Text response | Basic voice |
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      PRESENTATION LAYER                              │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                 │
+│  │ UI Components│  │ Voice Input │  │ Voice Output│                 │
+│  └──────┬──────┘  └──────┬──────┘  └──────▲──────┘                 │
+│         │                │                │                         │
+│         └────────────────┼────────────────┘                         │
+│                          ▼                                          │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │              UNIFIED INPUT NORMALIZER                        │   │
+│  │  Form Parser | Voice STT Parser | Chat Parser | Hybrid       │   │
+│  │                          ↓                                    │   │
+│  │              SEMANTIC INTENT EXTRACTOR (LLM)                 │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                     ORCHESTRATION LAYER                              │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │                  SAGE ORCHESTRATOR                           │   │
+│  │  Intent Router → Mode Decider → Response Strategy            │   │
+│  │                          ↓                                    │   │
+│  │         UI GENERATION AGENT (Grok-2 Tool)                    │   │
+│  │         Composes UITree from ~15 primitive components        │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                      OUTPUT LAYER                                    │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │              EXTENDED SAGEResponse                           │   │
+│  │  message | ui_tree (composable) | voice_hints                │   │
+│  │                          ↓                                    │   │
+│  │              MODALITY ADAPTERS                               │   │
+│  │  UI Renderer | Voice Synthesizer | Hybrid Mixer              │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Key Architecture Decision: Ad-Hoc UI Generation
+
+**Decision (see GitHub #83)**: We use **true ad-hoc UI generation** where the AI composes arbitrary UIs from primitive building blocks, rather than selecting from fixed SAGE-specific components.
+
+### Why Ad-Hoc Over Fixed Components?
+
+| Capability | Fixed Components | Ad-Hoc Generation |
+|------------|------------------|-------------------|
+| Predefined forms | ✅ | ✅ |
+| Custom verification quizzes | ❌ | ✅ |
+| Dynamic comparison tables | ❌ | ✅ |
+| Progress visualizations | ❌ | ✅ |
+| Context-aware UI adaptation | ❌ | ✅ |
+
+### Ad-Hoc Generation Flow
+
+```
+User Input (Voice/Form/Chat)
+         ↓
+Unified Input Normalizer
+         ↓
+Semantic Intent Extractor (LLM)
+         ↓
+SAGE Orchestrator
+    ├── Decides: "UI would help here"
+    └── Calls UI Agent (tool)
+              ↓
+         Grok-2 generates UITree from primitives (<500ms)
+              ↓
+Extended SAGEResponse (message + ui_tree + voice_hints)
+         ↓
+Frontend renders UITree recursively
+         ↓
+User interacts → data sent back to Orchestrator
+```
+
+## Core Components
+
+### 1. Unified Input Normalizer
+
+Converts any input type to a normalized semantic intent:
+
+```python
+@dataclass
+class NormalizedInput:
+    intent: str              # "session_check_in", "practice_setup", etc.
+    data: Dict[str, Any]     # Extracted structured data
+    data_complete: bool      # All required fields present?
+    missing_fields: List[str]
+    source_modality: InputModality  # FORM | VOICE | CHAT | HYBRID
+```
+
+### 2. Semantic Intent Extractor
+
+LLM-powered extraction of structured data from natural language:
+
+```python
+# Voice: "I have 30 minutes, feeling tired"
+# Extracts:
+{
+    "intent": "session_check_in",
+    "data": {
+        "timeAvailable": "focused",  # mapped from "30 minutes"
+        "energyLevel": 30,           # mapped from "tired"
+        "mindset": null              # not mentioned
+    },
+    "data_complete": false,
+    "missing_fields": ["mindset"]
+}
+```
+
+### 3. SAGE Orchestrator
+
+Central decision-maker that routes inputs and determines response format:
+
+**Decision Tree:**
+1. **INTENT CLASSIFICATION**: Form, Voice, Chat, or Hybrid?
+2. **DATA COMPLETENESS**: All required fields present?
+3. **ACTION DECISION**: Process action, or request more data?
+4. **OUTPUT STRATEGY**: Text only, UI tree, voice description, or hybrid?
+5. **UI GENERATION**: If UI needed, call UI Generation Agent as tool
+
+### 4. UI Generation Agent (Tool)
+
+Fast, composition-aware agent called by the orchestrator:
+
+- **Model**: Grok-2 (fast, <500ms target)
+- **Purpose**: Compose UITree from primitive components
+- **Architecture**: Called as tool by orchestrator (not monitoring conversation)
+- **Input**: Purpose + conversation context
+- **Output**: UITreeSpec with voice_fallback
+
+```python
+class UIGenerationAgent:
+    MODEL = "grok-2"
+    TEMPERATURE = 0.3  # Consistent structure
+
+    async def generate(
+        self,
+        purpose: str,
+        context: dict[str, Any],
+    ) -> UITreeSpec:
+        # Composes from primitives
+        pass
+```
+
+### 5. Extended SAGEResponse
+
+Enhanced response structure with composable UI tree:
+
+```python
+class UITreeNode(BaseModel):
+    """Recursive composable UI node."""
+    component: str  # Primitive component name
+    props: dict[str, Any] = Field(default_factory=dict)
+    children: list["UITreeNode"] | None = None
+
+class ExtendedSAGEResponse(SAGEResponse):
+    # Existing fields...
+
+    # New fields for modality parity
+    ui_tree: UITreeNode | None = None  # Composable tree
+    voice_hints: VoiceHints | None = None  # TTS optimization
+    pending_data_request: PendingDataRequest | None = None
+```
+
+## Primitive Component Library (~15 Components)
+
+Instead of fixed SAGE-specific components, we use reusable primitives:
+
+### Layout
+- `Stack` - Vertical/horizontal arrangement
+- `Grid` - Grid layout (1-4 columns)
+- `Card` - Contained section with optional title
+- `Divider` - Visual separator
+
+### Typography
+- `Text` - Text with variants (heading, body, caption)
+- `Markdown` - Rich text rendering
+
+### Inputs
+- `TextInput` - Single-line text
+- `TextArea` - Multi-line text
+- `Slider` - Numeric range
+- `RadioGroup` + `Radio` - Single selection
+- `Checkbox` - Boolean
+- `Select` - Dropdown selection
+
+### Actions
+- `Button` - Action trigger
+- `ButtonGroup` - Multiple buttons
+
+### Display
+- `Image` - Image display
+- `Table` - Data table
+- `ProgressBar` - Progress indicator
+- `Badge` - Status badge
+
+## Data Flow Examples
+
+### Voice Check-In Flow
+
+```
+User speaks: "I have about 30 minutes, feeling tired"
+    ↓
+Grok Voice STT: Transcription
+    ↓
+Semantic Intent Extractor:
+    intent=session_check_in,
+    data={timeAvailable: "focused", energyLevel: 30, mindset: null}
+    data_complete=false, missing=["mindset"]
+    ↓
+Orchestrator: request_more (conversational)
+    ↓
+SAGE speaks: "Got it - 30 minutes, lower energy. Anything on your mind?"
+    ↓
+User speaks: "Nervous about a pricing call tomorrow"
+    ↓
+Semantic Intent Extractor: merges with pending
+    data_complete=true
+    ↓
+Orchestrator: process action
+    ↓
+Backend: Store SessionContext, transition mode
+    ↓
+SAGE speaks: "Got it - I see you have that pricing call on your mind..."
+```
+
+### UI Check-In Flow (Ad-Hoc)
+
+```
+User opens session
+    ↓
+Orchestrator decides: UI would help for check-in
+    ↓
+UI Agent generates: UITree from primitives
+    {
+      component: "Stack",
+      children: [
+        { component: "Text", props: { content: "Quick Check-In" } },
+        { component: "RadioGroup", props: { name: "timeAvailable", ... } },
+        { component: "Slider", props: { name: "energyLevel", ... } },
+        { component: "TextArea", props: { name: "mindset", ... } },
+        { component: "Button", props: { label: "Let's begin" } }
+      ]
+    }
+    ↓
+Frontend renders UITree recursively
+    ↓
+User fills form, submits
+    ↓
+Form data sent via WebSocket: { form_id, data: {...} }
+    ↓
+Orchestrator: process action (same as voice path)
+    ↓
+Backend: Store SessionContext, transition mode
+```
+
+**Key insight**: Both paths execute the SAME backend action.
+
+## State Synchronization
+
+### Session State Machine
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      SESSION STATE                               │
+│                                                                  │
+│  ┌─────────────┐                                                │
+│  │ INIT        │ ← Session created                              │
+│  └──────┬──────┘                                                │
+│         │ startSession()                                        │
+│         ▼                                                       │
+│  ┌─────────────┐                                                │
+│  │ CHECKING_IN │ ← Gathering Set/Setting/Intention              │
+│  └──────┬──────┘                                                │
+│         │ checkInComplete()                                     │
+│         ▼                                                       │
+│  ┌─────────────┐                                                │
+│  │ ACTIVE      │ ← Normal dialogue loop                         │
+│  └──────┬──────┘                                                │
+│         │ endSession() | timeout                                │
+│         ▼                                                       │
+│  ┌─────────────┐                                                │
+│  │ ENDED       │                                                │
+│  └─────────────┘                                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Cross-Modality State Sync
+
+The same state is maintained regardless of input modality:
+
+```python
+class UnifiedSessionState:
+    session_id: str
+    modality_preference: InputModality  # User's preferred modality
+
+    # Pending data collection (survives modality switches)
+    pending_data_request: Optional[PendingDataRequest]
+
+    # Check-in state
+    check_in_data: Partial[SessionContext]
+    check_in_complete: bool
+
+    # Dialogue state
+    current_mode: DialogueMode
+    messages: List[Message]  # All messages, tagged with modality
+```
+
+### Storage Strategy
+
+- **sessionStorage**: Session-scoped data (pending data, session ID)
+- **localStorage**: User preferences (modality preference, voice enabled)
+
+## Implementation Phases
+
+### Phase 0: Prerequisites
+- #83 - ✅ DECIDED: Ad-Hoc UI Generation with Primitives
+- #84 - **BLOCKING**: WebSocket Protocol Extension
+
+### Phase 1: Foundation
+- #68 - Extended SAGEResponse with composable UITreeNode
+- #69 - Unified Input Normalizer
+- #70 - Semantic Intent Extractor
+
+### Phase 2: Orchestrator
+- #71 - SAGE Orchestrator Core
+- #72 - Pending Data Request Handling
+
+### Phase 3: UI Generation
+- #73 - Primitive UI Renderer Integration
+- #74 - Primitive Component Library (~15 components)
+- #75 - UI Generation Agent (Grok-2 composition tool)
+
+### Phase 4: Patterns & Verification
+- #76 - UI Patterns & Agent Verification
+
+### Phase 5: State Sync & Error Handling
+- #81 - Cross-Modality State Synchronization
+- #85 - Voice Error Recovery & Graceful Degradation
+
+### Phase 6: Testing & Polish
+- #82 - Integration Testing & Voice/UI Parity Verification
+- #87 - Accessibility for Voice/UI Parity
+
+## Error Handling
+
+### Network Interruption During Data Collection
+
+```python
+if connection_lost and pending_data_request:
+    # Store partial data in sessionStorage
+    SessionPersistence.setPendingData(pending_data_request)
+
+    # On reconnect, resume from where left off
+    if SessionPersistence.getPendingData():
+        resume_data_collection()
+```
+
+### Voice Transcription Errors
+
+```python
+if transcription_confidence < 0.7:
+    response = ExtendedSAGEResponse(
+        message="I didn't quite catch that. Could you say it again?",
+        voice_hints=VoiceHints(slower=True),
+    )
+```
+
+### Modality Mismatch
+
+```python
+if intent_expects_voice and not session.can_speak:
+    # Adapt to UI-only mode via ad-hoc generation
+    ui_tree = await ui_agent.generate(purpose=intent, context=session_context)
+    return ExtendedSAGEResponse(ui_tree=ui_tree, ...)
+```
+
+## Success Criteria
+
+1. **Full Feature Parity**: Every feature works in both voice and UI modes
+2. **Same Backend Actions**: Identical data structures stored regardless of input method
+3. **Seamless Switching**: User can switch modalities mid-session without data loss
+4. **Natural Voice Flow**: Voice interactions feel conversational, not form-filling
+5. **Responsive UI**: UI components provide instant feedback and validation
+6. **Ad-Hoc Flexibility**: AI can create custom UIs for any interaction type
+
+## Dependencies
+
+- **UI Renderer**: Custom recursive renderer (~100 lines) or json-render library
+- **json-render reference**: https://github.com/vercel-labs/json-render
+- **Grok-2**: Fast model for UI generation (<500ms target)
+- **Grok Voice API**: Already integrated
+- **FastAPI WebSocket**: Already implemented
+- **Pydantic v2**: Already used for all models
+
+## Related Documents
+
+- [System Design](./system-design.md)
+- [Data Model](./data-model.md)
+- [Context Management](./context-management.md)

--- a/src/sage/api/routes/chat.py
+++ b/src/sage/api/routes/chat.py
@@ -1,17 +1,35 @@
 """WebSocket chat handler for streaming responses."""
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 
 from sage.core.config import get_settings
 from sage.dialogue.conversation import ConversationEngine
+from sage.dialogue.structured_output import SAGEResponse
 from sage.graph.learning_graph import LearningGraph
 
 logger = logging.getLogger(__name__)
 
+
+# =============================================================================
+# WebSocket Message Models
+# =============================================================================
+
+
 router = APIRouter(tags=["chat"])
+
+
+class WSIncomingMessage(BaseModel):
+    """WebSocket message from client."""
+
+    type: str = "text"
+    content: Optional[str] = None
+    form_id: Optional[str] = None
+    data: Optional[dict[str, Any]] = None
+    is_voice: bool = False
 
 
 class ConnectionManager:
@@ -66,12 +84,12 @@ def _create_engine(graph: LearningGraph) -> ConversationEngine:
     )
 
 
-def _response_to_dict(response) -> dict:
+def _response_to_dict(response: SAGEResponse) -> dict:
     """Convert SAGEResponse to JSON-serializable dict."""
     gap = response.gap_identified
     proof = response.proof_earned
 
-    return {
+    result = {
         "message": response.message,
         "mode": response.current_mode.value,
         "transition_to": response.transition_to.value if response.transition_to else None,
@@ -87,7 +105,24 @@ def _response_to_dict(response) -> dict:
             "evidence": proof.evidence,
         } if proof else None,
         "outcome_achieved": response.outcome_achieved,
+        "ui_tree": None,
+        "voice_hints": None,
+        "pending_data_request": None,
+        "ui_purpose": None,
+        "estimated_interaction_time": None,
     }
+
+    # Add extended fields if present (ExtendedSAGEResponse)
+    for field in ("ui_tree", "voice_hints", "pending_data_request"):
+        value = getattr(response, field, None)
+        if value:
+            result[field] = value.model_dump()
+
+    for field in ("ui_purpose", "estimated_interaction_time"):
+        if hasattr(response, field):
+            result[field] = getattr(response, field)
+
+    return result
 
 
 @router.websocket("/api/chat/{session_id}")
@@ -136,6 +171,19 @@ async def websocket_chat(
         manager.disconnect(session_id)
 
 
+def _parse_incoming_message(data: dict) -> WSIncomingMessage:
+    """Parse incoming WebSocket data into a message object."""
+    try:
+        return WSIncomingMessage.model_validate(data)
+    except Exception:
+        # Fallback for legacy message format
+        return WSIncomingMessage(
+            type=data.get("type", "text"),
+            content=data.get("content", ""),
+            is_voice=data.get("is_voice", False),
+        )
+
+
 async def _handle_messages(session_id: str, engine: ConversationEngine) -> None:
     """Process incoming messages in the WebSocket loop."""
     websocket = manager.active_connections.get(session_id)
@@ -144,20 +192,29 @@ async def _handle_messages(session_id: str, engine: ConversationEngine) -> None:
 
     while True:
         data = await websocket.receive_json()
-        msg_type = data.get("type", "message")
-        content = data.get("content", "")
+        msg = _parse_incoming_message(data)
 
-        if msg_type == "voice" and data.get("audio") and not content:
-            await manager.send_error(
-                session_id, "Voice transcription not yet implemented"
-            )
-            continue
-
-        if not content:
+        if msg.type == "form_submission":
+            await _process_form_submission(session_id, engine, msg)
+        elif msg.type == "voice" and not msg.content:
+            await manager.send_error(session_id, "Voice transcription not yet implemented")
+        elif msg.content:
+            await _process_message(session_id, engine, msg.content)
+        else:
             await manager.send_error(session_id, "Empty message")
-            continue
 
-        await _process_message(session_id, engine, content)
+
+async def _stream_response(
+    session_id: str,
+    engine: ConversationEngine,
+    content: str,
+) -> None:
+    """Process content through the engine and stream the response."""
+    async def on_chunk(chunk: str) -> None:
+        await manager.send_chunk(session_id, chunk)
+
+    response = await engine.process_turn_streaming(content, on_chunk=on_chunk)
+    await manager.send_complete(session_id, _response_to_dict(response))
 
 
 async def _process_message(
@@ -165,13 +222,70 @@ async def _process_message(
     engine: ConversationEngine,
     content: str,
 ) -> None:
-    """Process a single message and send response via streaming."""
+    """Process a text message and send response via streaming."""
     try:
-        async def send_chunk(chunk: str) -> None:
-            await manager.send_chunk(session_id, chunk)
-
-        response = await engine.process_turn_streaming(content, on_chunk=send_chunk)
-        await manager.send_complete(session_id, _response_to_dict(response))
+        await _stream_response(session_id, engine, content)
     except Exception as e:
         logger.error(f"Error processing message: {e}")
         await manager.send_error(session_id, str(e))
+
+
+async def _process_form_submission(
+    session_id: str,
+    engine: ConversationEngine,
+    msg: WSIncomingMessage,
+) -> None:
+    """Process a form submission by converting to natural language."""
+    if not msg.form_id or not msg.data:
+        await manager.send_error(session_id, "Invalid form submission: missing form_id or data")
+        return
+
+    try:
+        form_description = _form_data_to_message(msg.form_id, msg.data)
+        await _stream_response(session_id, engine, form_description)
+    except Exception as e:
+        logger.error(f"Error processing form submission: {e}")
+        await manager.send_error(session_id, str(e))
+
+
+def _energy_level_to_text(level: Any) -> str:
+    """Convert energy level value to descriptive text."""
+    if not isinstance(level, (int, float)):
+        return str(level)
+    if level < 40:
+        return "low"
+    if level < 70:
+        return "medium"
+    return "high"
+
+
+def _form_data_to_message(form_id: str, data: dict[str, Any]) -> str:
+    """Convert form data to a natural language message."""
+    form_id_lower = form_id.lower()
+
+    # Session check-in form
+    if "check_in" in form_id_lower or "check-in" in form_id_lower:
+        time_map = {
+            "quick": "about 15 minutes",
+            "focused": "about 30 minutes",
+            "deep": "an hour or more",
+        }
+        parts = []
+        if "timeAvailable" in data:
+            time_text = time_map.get(data["timeAvailable"], data["timeAvailable"])
+            parts.append(f"I have {time_text}")
+        if "energyLevel" in data:
+            parts.append(f"my energy is {_energy_level_to_text(data['energyLevel'])}")
+        if data.get("mindset"):
+            parts.append(f"and {data['mindset']}")
+        return ". ".join(parts) if parts else "Starting session"
+
+    # Verification/quiz form
+    if "verification" in form_id_lower or "quiz" in form_id_lower:
+        if "answer" in data:
+            return f"My answer is: {data['answer']}"
+        return str(data)
+
+    # Generic form - convert to key-value description
+    parts = [f"{key}: {value}" for key, value in data.items() if value]
+    return "; ".join(parts) if parts else "Form submitted"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -264,3 +264,184 @@ class TestWebSocketChat:
             # Should fail to connect
             with client.websocket_connect("/api/chat/invalid-session"):
                 pass
+
+
+class TestWebSocketProtocolExtension:
+    """Test WebSocket protocol extension for voice/UI parity (#84)."""
+
+    def test_ws_incoming_message_text(self):
+        """Test WSIncomingMessage with text type."""
+        from sage.api.routes.chat import WSIncomingMessage
+
+        msg = WSIncomingMessage(type="text", content="Hello", is_voice=False)
+        assert msg.type == "text"
+        assert msg.content == "Hello"
+        assert msg.is_voice is False
+        assert msg.form_id is None
+        assert msg.data is None
+
+    def test_ws_incoming_message_form_submission(self):
+        """Test WSIncomingMessage with form_submission type."""
+        from sage.api.routes.chat import WSIncomingMessage
+
+        msg = WSIncomingMessage(
+            type="form_submission",
+            form_id="check-in-123",
+            data={"energyLevel": 50, "mindset": "focused"},
+        )
+        assert msg.type == "form_submission"
+        assert msg.form_id == "check-in-123"
+        assert msg.data == {"energyLevel": 50, "mindset": "focused"}
+        assert msg.content is None
+
+    def test_ws_incoming_message_defaults(self):
+        """Test WSIncomingMessage default values."""
+        from sage.api.routes.chat import WSIncomingMessage
+
+        msg = WSIncomingMessage()
+        assert msg.type == "text"
+        assert msg.is_voice is False
+
+    def test_form_data_to_message_check_in(self):
+        """Test _form_data_to_message with check-in form."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        # Full check-in data
+        result = _form_data_to_message("check-in-abc123", {
+            "timeAvailable": "focused",
+            "energyLevel": 75,
+            "mindset": "excited about the topic",
+        })
+        assert "about 30 minutes" in result
+        assert "high" in result
+        assert "excited about the topic" in result
+
+    def test_form_data_to_message_check_in_low_energy(self):
+        """Test _form_data_to_message with low energy."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        result = _form_data_to_message("session_check_in", {
+            "energyLevel": 20,
+        })
+        assert "low" in result
+
+    def test_form_data_to_message_check_in_medium_energy(self):
+        """Test _form_data_to_message with medium energy."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        result = _form_data_to_message("check_in_form", {
+            "energyLevel": 50,
+        })
+        assert "medium" in result
+
+    def test_form_data_to_message_verification(self):
+        """Test _form_data_to_message with verification form."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        result = _form_data_to_message("verification-quiz-123", {
+            "answer": "Start high with room to come down",
+        })
+        assert "My answer is:" in result
+        assert "Start high with room to come down" in result
+
+    def test_form_data_to_message_generic(self):
+        """Test _form_data_to_message with generic form."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        result = _form_data_to_message("custom-form", {
+            "name": "John",
+            "topic": "pricing",
+        })
+        assert "name: John" in result
+        assert "topic: pricing" in result
+
+    def test_form_data_to_message_empty(self):
+        """Test _form_data_to_message with empty data."""
+        from sage.api.routes.chat import _form_data_to_message
+
+        result = _form_data_to_message("check-in", {})
+        assert result == "Starting session"
+
+        result = _form_data_to_message("generic", {})
+        assert result == "Form submitted"
+
+    def test_response_to_dict_includes_ui_fields(self):
+        """Test _response_to_dict includes voice/UI parity fields."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import SAGEResponse
+        from sage.graph.models import DialogueMode
+
+        response = SAGEResponse(
+            message="Hello!",
+            current_mode=DialogueMode.CHECK_IN,
+        )
+
+        result = _response_to_dict(response)
+
+        # Should have all the standard fields
+        assert result["message"] == "Hello!"
+        assert result["mode"] == "check_in"
+
+        # Should have voice/UI parity fields (null for base SAGEResponse)
+        assert "ui_tree" in result
+        assert "voice_hints" in result
+        assert "pending_data_request" in result
+        assert "ui_purpose" in result
+        assert "estimated_interaction_time" in result
+
+    def test_response_to_dict_with_extended_response(self):
+        """Test _response_to_dict with ExtendedSAGEResponse."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import (
+            ExtendedSAGEResponse,
+            UITreeNode,
+            VoiceHints,
+            PendingDataRequest,
+        )
+        from sage.graph.models import DialogueMode
+
+        ui_tree = UITreeNode(
+            component="Stack",
+            props={"gap": 4},
+            children=[
+                UITreeNode(component="Text", props={"content": "Hello"}),
+            ],
+        )
+        voice_hints = VoiceHints(
+            voice_fallback="Hello, how are you?",
+            emphasis=["Hello"],
+            tone="friendly",
+        )
+        pending = PendingDataRequest(
+            intent="check_in",
+            collected_data={"energyLevel": 50},
+            missing_fields=["mindset"],
+        )
+
+        response = ExtendedSAGEResponse(
+            message="Hello!",
+            current_mode=DialogueMode.CHECK_IN,
+            ui_tree=ui_tree,
+            voice_hints=voice_hints,
+            pending_data_request=pending,
+            ui_purpose="Gather session context",
+            estimated_interaction_time=30,
+        )
+
+        result = _response_to_dict(response)
+
+        # Check extended fields are serialized
+        assert result["ui_tree"] is not None
+        assert result["ui_tree"]["component"] == "Stack"
+        assert len(result["ui_tree"]["children"]) == 1
+
+        assert result["voice_hints"] is not None
+        assert result["voice_hints"]["voice_fallback"] == "Hello, how are you?"
+        assert result["voice_hints"]["tone"] == "friendly"
+
+        assert result["pending_data_request"] is not None
+        assert result["pending_data_request"]["intent"] == "check_in"
+        assert result["pending_data_request"]["missing_fields"] == ["mindset"]
+
+        assert result["ui_purpose"] == "Gather session context"
+        assert result["estimated_interaction_time"] == 30


### PR DESCRIPTION
## Summary

- Extends WebSocket protocol to support form submissions and voice/UI parity fields
- Backend serializes ExtendedSAGEResponse fields (ui_tree, voice_hints, pending_data_request)
- Frontend can now submit form data via `sendFormSubmission(formId, data)`

## Changes

### Backend (`src/sage/api/routes/chat.py`)
- `WSIncomingMessage` model for typed messages (text, form_submission)
- `_response_to_dict()` includes voice/UI parity fields
- `_process_form_submission()` converts form data to natural language
- `_form_data_to_message()` handles check-in, verification, generic forms

### Frontend (`web/lib/websocket.ts`)
- `sendFormSubmission(formId, data)` method
- `WSOutgoingMessage` type union
- `ConnectionStatus` type alias

## Test plan

- [x] 11 new unit tests for all new functionality
- [x] All 303 tests pass (1 pre-existing failure)
- [ ] Manual test: form submission flow
- [ ] Manual test: extended response fields in UI

Closes #84