### PR TITLE
feat(orchestration): Unified Input Normalizer (#69)

### DIFF
--- a/src/sage/orchestration/__init__.py
+++ b/src/sage/orchestration/__init__.py
@@ -1,0 +1,17 @@
+"""SAGE Orchestration Layer.
+
+This module handles input normalization, intent extraction, and
+orchestration of the voice/UI parity system.
+"""
+
+from sage.orchestration.normalizer import (
+    InputModality,
+    InputNormalizer,
+    NormalizedInput,
+)
+
+__all__ = [
+    "InputModality",
+    "InputNormalizer",
+    "NormalizedInput",
+]

--- a/src/sage/orchestration/normalizer.py
+++ b/src/sage/orchestration/normalizer.py
@@ -1,0 +1,247 @@
+"""Unified Input Normalizer for Voice/UI Parity.
+
+Converts any input type (form, voice, chat) to a normalized semantic
+intent structure for consistent processing by the SAGE orchestrator.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class InputModality(Enum):
+    """Source modality for user input."""
+
+    FORM = "form"
+    VOICE = "voice"
+    CHAT = "chat"
+    HYBRID = "hybrid"  # Mixed modality (e.g., voice + form prefill)
+
+
+@dataclass
+class NormalizedInput:
+    """Unified input regardless of source modality.
+
+    This structure is the common format used by the SAGE orchestrator,
+    regardless of whether input came from a form, voice, or chat.
+    """
+
+    intent: str
+    """Semantic intent identifier (e.g., 'session_check_in', 'practice_setup')."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+    """Extracted structured data from the input."""
+
+    data_complete: bool = False
+    """Whether all required fields for this intent are present."""
+
+    missing_fields: list[str] = field(default_factory=list)
+    """Fields still needed to complete the intent."""
+
+    validation_errors: list[str] = field(default_factory=list)
+    """Validation failures encountered during normalization."""
+
+    source_modality: InputModality = InputModality.CHAT
+    """Where the input came from."""
+
+    raw_input: str = ""
+    """Original input for context and debugging."""
+
+
+FORM_SCHEMAS: dict[str, dict[str, Any]] = {
+    "session_check_in": {
+        "required": [],  # All fields optional for flexibility
+        "optional": ["timeAvailable", "energyLevel", "mindset"],
+        "validators": {
+            "timeAvailable": lambda v: v in ("quick", "focused", "deep"),
+            "energyLevel": lambda v: isinstance(v, (int, float)) and 0 <= v <= 100,
+        },
+    },
+    "practice_setup": {
+        "required": ["scenario_type"],
+        "optional": ["difficulty", "context", "focus_area"],
+        "validators": {
+            "difficulty": lambda v: v in ("easy", "medium", "hard"),
+        },
+    },
+    "verification": {
+        "required": ["answer"],
+        "optional": ["confidence", "notes"],
+        "validators": {
+            "confidence": lambda v: isinstance(v, (int, float)) and 0 <= v <= 100,
+        },
+    },
+    "outcome_discovery": {
+        "required": [],
+        "optional": ["goal", "context", "timeline"],
+        "validators": {},
+    },
+    "application_event": {
+        "required": [],
+        "optional": ["context", "planned_date", "stakes"],
+        "validators": {
+            "stakes": lambda v: v in ("low", "medium", "high"),
+        },
+    },
+}
+
+
+_DEFAULT_SCHEMA: dict[str, Any] = {"required": [], "optional": [], "validators": {}}
+
+_FORM_ID_TO_INTENT: list[tuple[tuple[str, ...], str]] = [
+    (("check_in", "check-in"), "session_check_in"),
+    (("practice", "scenario"), "practice_setup"),
+    (("verification", "quiz"), "verification"),
+    (("outcome", "goal"), "outcome_discovery"),
+    (("application", "event"), "application_event"),
+]
+
+
+def _infer_intent_from_form_id(form_id: str) -> str:
+    """Infer semantic intent from form ID.
+
+    Maps form IDs (like 'check-in-abc123') to semantic intents
+    (like 'session_check_in').
+    """
+    form_id_lower = form_id.lower()
+    for keywords, intent in _FORM_ID_TO_INTENT:
+        if any(keyword in form_id_lower for keyword in keywords):
+            return intent
+    return "generic_form"
+
+
+def _validate_against_schema(
+    intent: str,
+    data: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Validate data against the schema for an intent.
+
+    Returns:
+        Tuple of (missing_fields, validation_errors)
+    """
+    schema = FORM_SCHEMAS.get(intent, _DEFAULT_SCHEMA)
+    missing_fields = []
+    validation_errors = []
+
+    for field_name in schema.get("required", []):
+        if field_name not in data or data[field_name] is None:
+            missing_fields.append(field_name)
+
+    validators = schema.get("validators", {})
+    for field_name, value in data.items():
+        if field_name in validators and value is not None:
+            try:
+                if not validators[field_name](value):
+                    validation_errors.append(f"Invalid value for {field_name}: {value}")
+            except Exception as e:
+                validation_errors.append(f"Validation error for {field_name}: {e}")
+
+    return missing_fields, validation_errors
+
+
+class InputNormalizer:
+    """Converts any input to NormalizedInput.
+
+    This class handles the first stage of the voice/UI parity pipeline:
+    taking raw input from any modality and converting it to a standard
+    format for downstream processing.
+    """
+
+    def normalize_form(
+        self,
+        form_id: str,
+        data: dict[str, Any],
+    ) -> NormalizedInput:
+        """Normalize form submission.
+
+        Form data is already structured, so we just need to:
+        1. Infer the intent from the form ID
+        2. Validate against the schema
+        3. Identify any missing required fields
+        """
+        intent = _infer_intent_from_form_id(form_id)
+        missing_fields, validation_errors = _validate_against_schema(intent, data)
+
+        return NormalizedInput(
+            intent=intent,
+            data=data,
+            data_complete=not missing_fields and not validation_errors,
+            missing_fields=missing_fields,
+            validation_errors=validation_errors,
+            source_modality=InputModality.FORM,
+            raw_input=f"form:{form_id}",
+        )
+
+    def _normalize_unstructured(
+        self,
+        raw_input: str,
+        modality: InputModality,
+        pending_data: dict[str, Any] | None = None,
+    ) -> NormalizedInput:
+        """Normalize unstructured input (voice, chat, or hybrid).
+
+        Unstructured input requires semantic extraction by the Intent Extractor.
+        Intent is marked as 'pending_extraction' until extracted downstream.
+        """
+        return NormalizedInput(
+            intent="pending_extraction",
+            data=dict(pending_data) if pending_data else {},
+            data_complete=False,
+            source_modality=modality,
+            raw_input=raw_input,
+        )
+
+    def normalize_voice(
+        self,
+        transcript: str,
+        pending: dict[str, Any] | None = None,
+    ) -> NormalizedInput:
+        """Normalize voice transcription."""
+        return self._normalize_unstructured(transcript, InputModality.VOICE, pending)
+
+    def normalize_chat(
+        self,
+        message: str,
+        pending: dict[str, Any] | None = None,
+    ) -> NormalizedInput:
+        """Normalize chat message."""
+        return self._normalize_unstructured(message, InputModality.CHAT, pending)
+
+    def normalize_hybrid(
+        self,
+        message: str,
+        form_data: dict[str, Any] | None = None,
+        modality: InputModality = InputModality.HYBRID,
+    ) -> NormalizedInput:
+        """Normalize hybrid input (voice/chat with form prefill)."""
+        return self._normalize_unstructured(message, modality, form_data)
+
+    def merge_with_pending(
+        self,
+        new_input: NormalizedInput,
+        pending_data: dict[str, Any],
+        pending_intent: str,
+    ) -> NormalizedInput:
+        """Merge new input with pending incomplete data.
+
+        This is used when collecting data across multiple turns.
+        The new input's data is merged into the pending data.
+
+        Args:
+            new_input: The newly normalized input
+            pending_data: Data collected in previous turns
+            pending_intent: The intent we're collecting data for
+        """
+        merged = {**pending_data, **new_input.data}
+        intent = pending_intent if new_input.intent == "pending_extraction" else new_input.intent
+        missing_fields, validation_errors = _validate_against_schema(intent, merged)
+
+        return NormalizedInput(
+            intent=intent,
+            data=merged,
+            data_complete=not missing_fields and not validation_errors,
+            missing_fields=missing_fields,
+            validation_errors=validation_errors,
+            source_modality=new_input.source_modality,
+            raw_input=new_input.raw_input,
+        )

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,389 @@
+"""Tests for the Unified Input Normalizer."""
+
+import pytest
+
+from sage.orchestration.normalizer import (
+    FORM_SCHEMAS,
+    InputModality,
+    InputNormalizer,
+    NormalizedInput,
+    _infer_intent_from_form_id,
+)
+
+
+@pytest.fixture
+def normalizer() -> InputNormalizer:
+    """Create normalizer instance for tests."""
+    return InputNormalizer()
+
+
+class TestInputModality:
+    """Test InputModality enum."""
+
+    def test_enum_values(self):
+        """Test all modality values exist."""
+        assert InputModality.FORM.value == "form"
+        assert InputModality.VOICE.value == "voice"
+        assert InputModality.CHAT.value == "chat"
+        assert InputModality.HYBRID.value == "hybrid"
+
+
+class TestNormalizedInput:
+    """Test NormalizedInput dataclass."""
+
+    def test_default_values(self):
+        """Test default values are set correctly."""
+        normalized = NormalizedInput(intent="test")
+        assert normalized.intent == "test"
+        assert normalized.data == {}
+        assert normalized.data_complete is False
+        assert normalized.missing_fields == []
+        assert normalized.validation_errors == []
+        assert normalized.source_modality == InputModality.CHAT
+        assert normalized.raw_input == ""
+
+    def test_custom_values(self):
+        """Test custom values are preserved."""
+        normalized = NormalizedInput(
+            intent="session_check_in",
+            data={"energyLevel": 75},
+            data_complete=True,
+            missing_fields=[],
+            validation_errors=[],
+            source_modality=InputModality.FORM,
+            raw_input="form:check-in-123",
+        )
+        assert normalized.intent == "session_check_in"
+        assert normalized.data["energyLevel"] == 75
+        assert normalized.data_complete is True
+        assert normalized.source_modality == InputModality.FORM
+
+
+class TestInferIntentFromFormId:
+    """Test form ID to intent inference."""
+
+    @pytest.mark.parametrize(
+        "form_id,expected",
+        [
+            # Check-in variations
+            ("check-in-abc123", "session_check_in"),
+            ("check_in_form", "session_check_in"),
+            ("session_check_in", "session_check_in"),
+            ("CHECK-IN", "session_check_in"),
+            # Practice variations
+            ("practice-setup-123", "practice_setup"),
+            ("scenario_form", "practice_setup"),
+            # Verification variations
+            ("verification-quiz-abc", "verification"),
+            ("quiz_form", "verification"),
+            # Outcome variations
+            ("outcome_discovery", "outcome_discovery"),
+            ("goal-form", "outcome_discovery"),
+            # Application variations
+            ("application-event-123", "application_event"),
+            ("event_form", "application_event"),
+            # Generic fallback
+            ("unknown-form", "generic_form"),
+            ("random123", "generic_form"),
+        ],
+    )
+    def test_intent_inference(self, form_id: str, expected: str) -> None:
+        """Test form ID to intent mapping."""
+        assert _infer_intent_from_form_id(form_id) == expected
+
+
+class TestInputNormalizerForm:
+    """Test InputNormalizer.normalize_form()."""
+
+    def test_check_in_complete(self, normalizer):
+        """Test normalizing complete check-in form."""
+        result = normalizer.normalize_form(
+            "check-in-123",
+            {
+                "timeAvailable": "focused",
+                "energyLevel": 75,
+                "mindset": "excited to learn",
+            },
+        )
+        assert result.intent == "session_check_in"
+        assert result.data_complete is True
+        assert result.source_modality == InputModality.FORM
+        assert len(result.missing_fields) == 0
+        assert len(result.validation_errors) == 0
+
+    def test_check_in_empty(self, normalizer):
+        """Test normalizing empty check-in form (all optional)."""
+        result = normalizer.normalize_form("check_in", {})
+        assert result.intent == "session_check_in"
+        assert result.data_complete is True  # No required fields
+        assert len(result.missing_fields) == 0
+
+    def test_check_in_invalid_time(self, normalizer):
+        """Test validation error for invalid timeAvailable."""
+        result = normalizer.normalize_form(
+            "check-in",
+            {"timeAvailable": "invalid_option"},
+        )
+        assert result.intent == "session_check_in"
+        assert result.data_complete is False
+        assert len(result.validation_errors) == 1
+        assert "timeAvailable" in result.validation_errors[0]
+
+    def test_check_in_invalid_energy(self, normalizer):
+        """Test validation error for out-of-range energy level."""
+        result = normalizer.normalize_form(
+            "check-in",
+            {"energyLevel": 150},  # Out of range
+        )
+        assert result.data_complete is False
+        assert len(result.validation_errors) == 1
+        assert "energyLevel" in result.validation_errors[0]
+
+    def test_practice_missing_required(self, normalizer):
+        """Test missing required field in practice setup."""
+        result = normalizer.normalize_form(
+            "practice-setup",
+            {"difficulty": "medium"},
+        )
+        assert result.intent == "practice_setup"
+        assert result.data_complete is False
+        assert "scenario_type" in result.missing_fields
+
+    def test_practice_complete(self, normalizer):
+        """Test complete practice setup form."""
+        result = normalizer.normalize_form(
+            "practice-setup",
+            {"scenario_type": "pricing_call", "difficulty": "hard"},
+        )
+        assert result.intent == "practice_setup"
+        assert result.data_complete is True
+        assert len(result.missing_fields) == 0
+
+    def test_verification_form(self, normalizer):
+        """Test verification form normalization."""
+        result = normalizer.normalize_form(
+            "verification-quiz-123",
+            {"answer": "Start high with room to come down"},
+        )
+        assert result.intent == "verification"
+        assert result.data_complete is True
+        assert result.data["answer"] == "Start high with room to come down"
+
+    def test_generic_form(self, normalizer):
+        """Test unknown form type falls back to generic."""
+        result = normalizer.normalize_form(
+            "custom-form",
+            {"field1": "value1", "field2": 42},
+        )
+        assert result.intent == "generic_form"
+        assert result.data == {"field1": "value1", "field2": 42}
+        assert result.data_complete is True  # No required fields for generic
+
+    def test_raw_input_preserved(self, normalizer):
+        """Test raw input is preserved."""
+        result = normalizer.normalize_form("my-form", {"key": "value"})
+        assert result.raw_input == "form:my-form"
+
+
+class TestInputNormalizerVoice:
+    """Test InputNormalizer.normalize_voice()."""
+
+    def test_simple_transcript(self, normalizer):
+        """Test normalizing simple voice transcript."""
+        result = normalizer.normalize_voice(
+            "I have about thirty minutes and feeling energized"
+        )
+        assert result.intent == "pending_extraction"
+        assert result.source_modality == InputModality.VOICE
+        assert result.raw_input == "I have about thirty minutes and feeling energized"
+        assert result.data_complete is False
+
+    def test_with_pending_data(self, normalizer):
+        """Test merging with pending data."""
+        result = normalizer.normalize_voice(
+            "and I'm feeling pretty focused",
+            pending={"timeAvailable": "focused"},
+        )
+        assert result.data["timeAvailable"] == "focused"
+        assert result.source_modality == InputModality.VOICE
+
+    def test_empty_pending(self, normalizer):
+        """Test with empty pending data."""
+        result = normalizer.normalize_voice("Hello", pending={})
+        assert result.data == {}
+
+
+class TestInputNormalizerChat:
+    """Test InputNormalizer.normalize_chat()."""
+
+    def test_simple_message(self, normalizer):
+        """Test normalizing simple chat message."""
+        result = normalizer.normalize_chat("I want to learn pricing strategies")
+        assert result.intent == "pending_extraction"
+        assert result.source_modality == InputModality.CHAT
+        assert result.raw_input == "I want to learn pricing strategies"
+
+    def test_with_pending_data(self, normalizer):
+        """Test merging with pending data."""
+        result = normalizer.normalize_chat(
+            "My energy is high",
+            pending={"timeAvailable": "deep"},
+        )
+        assert result.data["timeAvailable"] == "deep"
+        assert result.source_modality == InputModality.CHAT
+
+
+class TestInputNormalizerHybrid:
+    """Test InputNormalizer.normalize_hybrid()."""
+
+    def test_voice_with_form_prefill(self, normalizer):
+        """Test voice input with form data prefill."""
+        result = normalizer.normalize_hybrid(
+            "I'm feeling pretty tired though",
+            form_data={"timeAvailable": "quick"},
+            modality=InputModality.VOICE,
+        )
+        assert result.intent == "pending_extraction"
+        assert result.data["timeAvailable"] == "quick"
+        assert result.source_modality == InputModality.VOICE
+        assert result.raw_input == "I'm feeling pretty tired though"
+
+    def test_chat_with_form_prefill(self, normalizer):
+        """Test chat input with form data prefill."""
+        result = normalizer.normalize_hybrid(
+            "Actually let me change my answer",
+            form_data={"answer": "old answer"},
+            modality=InputModality.CHAT,
+        )
+        assert result.data["answer"] == "old answer"
+        assert result.source_modality == InputModality.CHAT
+
+    def test_no_form_data(self, normalizer):
+        """Test hybrid without form data."""
+        result = normalizer.normalize_hybrid("Just some text")
+        assert result.data == {}
+        assert result.source_modality == InputModality.HYBRID
+
+
+class TestInputNormalizerMerge:
+    """Test InputNormalizer.merge_with_pending()."""
+
+    def test_merge_adds_new_fields(self, normalizer):
+        """Test merging adds new fields to pending data."""
+        new_input = NormalizedInput(
+            intent="pending_extraction",
+            data={"energyLevel": 80},
+            source_modality=InputModality.VOICE,
+            raw_input="I'm feeling energized",
+        )
+
+        result = normalizer.merge_with_pending(
+            new_input,
+            pending_data={"timeAvailable": "focused"},
+            pending_intent="session_check_in",
+        )
+
+        assert result.data["timeAvailable"] == "focused"
+        assert result.data["energyLevel"] == 80
+        assert result.intent == "session_check_in"
+
+    def test_merge_overwrites_existing(self, normalizer):
+        """Test new input overwrites existing fields."""
+        new_input = NormalizedInput(
+            intent="pending_extraction",
+            data={"energyLevel": 30},  # New value
+            source_modality=InputModality.CHAT,
+            raw_input="Actually I'm tired now",
+        )
+
+        result = normalizer.merge_with_pending(
+            new_input,
+            pending_data={"energyLevel": 80, "timeAvailable": "deep"},
+            pending_intent="session_check_in",
+        )
+
+        assert result.data["energyLevel"] == 30  # Overwritten
+        assert result.data["timeAvailable"] == "deep"  # Preserved
+
+    def test_merge_validates_against_schema(self, normalizer):
+        """Test merged data is validated against schema."""
+        new_input = NormalizedInput(
+            intent="pending_extraction",
+            data={"energyLevel": 200},  # Invalid
+            source_modality=InputModality.VOICE,
+            raw_input="test",
+        )
+
+        result = normalizer.merge_with_pending(
+            new_input,
+            pending_data={},
+            pending_intent="session_check_in",
+        )
+
+        assert result.data_complete is False
+        assert len(result.validation_errors) == 1
+
+    def test_merge_uses_new_intent_when_determined(self, normalizer):
+        """Test uses new input's intent when not pending_extraction."""
+        new_input = NormalizedInput(
+            intent="verification",  # Determined intent
+            data={"answer": "test answer"},
+            source_modality=InputModality.FORM,
+            raw_input="form:verification-123",
+        )
+
+        result = normalizer.merge_with_pending(
+            new_input,
+            pending_data={},
+            pending_intent="session_check_in",
+        )
+
+        assert result.intent == "verification"  # Uses new, not pending
+
+    def test_merge_checks_required_fields(self, normalizer):
+        """Test merge identifies missing required fields."""
+        new_input = NormalizedInput(
+            intent="pending_extraction",
+            data={"difficulty": "hard"},
+            source_modality=InputModality.CHAT,
+            raw_input="hard mode please",
+        )
+
+        result = normalizer.merge_with_pending(
+            new_input,
+            pending_data={},
+            pending_intent="practice_setup",
+        )
+
+        assert result.data_complete is False
+        assert "scenario_type" in result.missing_fields
+
+
+class TestFormSchemas:
+    """Test form schema definitions."""
+
+    def test_session_check_in_schema_exists(self):
+        """Test session check-in schema is defined."""
+        assert "session_check_in" in FORM_SCHEMAS
+        schema = FORM_SCHEMAS["session_check_in"]
+        assert "required" in schema
+        assert "optional" in schema
+        assert "validators" in schema
+
+    def test_practice_setup_schema_exists(self):
+        """Test practice setup schema is defined."""
+        assert "practice_setup" in FORM_SCHEMAS
+        schema = FORM_SCHEMAS["practice_setup"]
+        assert "scenario_type" in schema["required"]
+
+    def test_verification_schema_exists(self):
+        """Test verification schema is defined."""
+        assert "verification" in FORM_SCHEMAS
+        schema = FORM_SCHEMAS["verification"]
+        assert "answer" in schema["required"]
+
+    def test_validators_callable(self):
+        """Test all validators are callable."""
+        for intent, schema in FORM_SCHEMAS.items():
+            for field, validator in schema.get("validators", {}).items():
+                assert callable(validator), f"{intent}.{field} validator not callable"


### PR DESCRIPTION
## Summary

Implements the Unified Input Normalizer for Voice/UI Parity (Phase 1.2 of epic #67).

- Creates `InputModality` enum for tracking input source (form, voice, chat, hybrid)
- Creates `NormalizedInput` dataclass as the common format for all inputs
- Creates `InputNormalizer` class with methods for each modality type
- Includes form validation schemas for known form types
- Supports multi-turn data collection via `merge_with_pending()`

## Key Files

- `src/sage/orchestration/__init__.py` - New orchestration module
- `src/sage/orchestration/normalizer.py` - Core normalizer implementation
- `tests/test_normalizer.py` - 43 comprehensive tests

## Test plan

- [x] All 43 normalizer tests pass
- [x] Full test suite passes (338 tests, 1 pre-existing failure)
- [x] Code simplifier applied for clarity

Closes #69