### PR TITLE
feat(web): add stub pages for Settings, Goals, Proofs (#64)

### DIFF
--- a/tests/test_stub_pages.py
+++ b/tests/test_stub_pages.py
@@ -1,0 +1,105 @@
+"""
+Tests for stub pages (#64) - Settings, Goals, Proofs
+
+These tests document the page requirements and ensure
+the stub pages are properly structured.
+"""
+
+import pytest
+from pathlib import Path
+
+
+class TestStubPageStructure:
+    """Test that stub pages exist and have proper structure."""
+
+    @pytest.fixture
+    def web_app_dir(self) -> Path:
+        """Get the web app directory."""
+        return Path(__file__).parent.parent / "web" / "app"
+
+    def test_settings_page_exists(self, web_app_dir: Path) -> None:
+        """Settings page should exist at /settings."""
+        settings_page = web_app_dir / "settings" / "page.tsx"
+        assert settings_page.exists(), "Settings page.tsx should exist"
+
+    def test_goals_page_exists(self, web_app_dir: Path) -> None:
+        """Goals page should exist at /goals."""
+        goals_page = web_app_dir / "goals" / "page.tsx"
+        assert goals_page.exists(), "Goals page.tsx should exist"
+
+    def test_proofs_page_exists(self, web_app_dir: Path) -> None:
+        """Proofs page should exist at /proofs."""
+        proofs_page = web_app_dir / "proofs" / "page.tsx"
+        assert proofs_page.exists(), "Proofs page.tsx should exist"
+
+
+class TestStubPageContent:
+    """Test that stub pages have appropriate content."""
+
+    @pytest.fixture
+    def web_app_dir(self) -> Path:
+        """Get the web app directory."""
+        return Path(__file__).parent.parent / "web" / "app"
+
+    def test_settings_page_has_coming_soon(self, web_app_dir: Path) -> None:
+        """Settings page should indicate it's coming soon."""
+        content = (web_app_dir / "settings" / "page.tsx").read_text()
+        assert "Coming Soon" in content
+
+    def test_goals_page_has_coming_soon(self, web_app_dir: Path) -> None:
+        """Goals page should indicate it's coming soon."""
+        content = (web_app_dir / "goals" / "page.tsx").read_text()
+        assert "Coming Soon" in content
+
+    def test_proofs_page_has_coming_soon(self, web_app_dir: Path) -> None:
+        """Proofs page should indicate it's coming soon."""
+        content = (web_app_dir / "proofs" / "page.tsx").read_text()
+        assert "Coming Soon" in content
+
+    def test_settings_lists_planned_features(self, web_app_dir: Path) -> None:
+        """Settings page should list planned features."""
+        content = (web_app_dir / "settings" / "page.tsx").read_text()
+        assert "Dark mode" in content
+        assert "Voice preferences" in content
+        assert "API configuration" in content
+        assert "Learner profile" in content
+
+    def test_goals_lists_planned_features(self, web_app_dir: Path) -> None:
+        """Goals page should list planned features."""
+        content = (web_app_dir / "goals" / "page.tsx").read_text()
+        assert "learning goals" in content
+        assert "completed outcomes" in content
+
+    def test_proofs_lists_planned_features(self, web_app_dir: Path) -> None:
+        """Proofs page should list planned features."""
+        content = (web_app_dir / "proofs" / "page.tsx").read_text()
+        assert "earned proofs" in content
+        assert "confidence" in content
+
+
+class TestSidebarNavigation:
+    """Test that sidebar navigation links to stub pages."""
+
+    @pytest.fixture
+    def sidebar_content(self) -> str:
+        """Get sidebar component content."""
+        sidebar_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "layout"
+            / "Sidebar.tsx"
+        )
+        return sidebar_path.read_text()
+
+    def test_sidebar_links_to_settings(self, sidebar_content: str) -> None:
+        """Sidebar should have link to /settings."""
+        assert 'href: "/settings"' in sidebar_content
+
+    def test_sidebar_links_to_goals(self, sidebar_content: str) -> None:
+        """Sidebar should have link to /goals."""
+        assert 'href: "/goals"' in sidebar_content
+
+    def test_sidebar_links_to_proofs(self, sidebar_content: str) -> None:
+        """Sidebar should have link to /proofs."""
+        assert 'href: "/proofs"' in sidebar_content

--- a/web/app/goals/page.tsx
+++ b/web/app/goals/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Target, CheckCircle, Circle, Clock } from "lucide-react";
+
+export default function GoalsPage(): JSX.Element {
+  const plannedFeatures = [
+    { icon: Target, label: "View all learning goals" },
+    { icon: CheckCircle, label: "Track completed outcomes" },
+    { icon: Circle, label: "Monitor active goals" },
+    { icon: Clock, label: "See goal history" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+            Goals
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Track your learning outcomes
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center max-w-md">
+          <Target className="h-16 w-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+          <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300 mb-2">
+            Coming Soon
+          </h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-6">
+            Goals page is under development. Planned features include:
+          </p>
+          <ul className="space-y-3">
+            {plannedFeatures.map(({ icon: Icon, label }) => (
+              <li
+                key={label}
+                className="flex items-center gap-3 text-slate-600 dark:text-slate-400"
+              >
+                <Icon className="h-5 w-5 text-sage-500" />
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/proofs/page.tsx
+++ b/web/app/proofs/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Award, FileCheck, Star, History } from "lucide-react";
+
+export default function ProofsPage(): JSX.Element {
+  const plannedFeatures = [
+    { icon: Award, label: "View earned proofs" },
+    { icon: FileCheck, label: "Review proof details" },
+    { icon: Star, label: "Track proof confidence" },
+    { icon: History, label: "See verification history" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+            Proofs
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Your demonstrated understanding
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center max-w-md">
+          <Award className="h-16 w-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+          <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300 mb-2">
+            Coming Soon
+          </h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-6">
+            Proofs page is under development. Planned features include:
+          </p>
+          <ul className="space-y-3">
+            {plannedFeatures.map(({ icon: Icon, label }) => (
+              <li
+                key={label}
+                className="flex items-center gap-3 text-slate-600 dark:text-slate-400"
+              >
+                <Icon className="h-5 w-5 text-sage-500" />
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Settings, Moon, Mic, Key, User } from "lucide-react";
+
+export default function SettingsPage(): JSX.Element {
+  const plannedFeatures = [
+    { icon: Moon, label: "Dark mode toggle" },
+    { icon: Mic, label: "Voice preferences" },
+    { icon: Key, label: "API configuration" },
+    { icon: User, label: "Learner profile" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+            Settings
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Customize your SAGE experience
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center max-w-md">
+          <Settings className="h-16 w-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+          <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300 mb-2">
+            Coming Soon
+          </h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-6">
+            Settings page is under development. Planned features include:
+          </p>
+          <ul className="space-y-3">
+            {plannedFeatures.map(({ icon: Icon, label }) => (
+              <li
+                key={label}
+                className="flex items-center gap-3 text-slate-600 dark:text-slate-400"
+              >
+                <Icon className="h-5 w-5 text-sage-500" />
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fix 404 errors when clicking Settings, Goals, and Proofs links in sidebar navigation.

### New Pages
- `/settings` - Lists planned features (dark mode, voice prefs, API config, profile)
- `/goals` - Lists planned features (view goals, track outcomes, history)
- `/proofs` - Lists planned features (view proofs, confidence tracking, history)

Each page follows the existing design pattern with a header and centered "Coming Soon" content.

### Tests
- 12 tests verifying page structure, content, and sidebar links

## Test Plan
- [x] TypeScript compiles
- [x] All 12 tests pass
- [ ] Manual verification: sidebar links no longer 404

Closes #64