### PR TITLE
feat(web): add voice mode and dual input support to check-in (#59)

### DIFF
--- a/tests/test_check_in_voice_support.py
+++ b/tests/test_check_in_voice_support.py
@@ -1,0 +1,219 @@
+"""
+Tests for Check-in Voice Support (#59)
+
+These tests verify that the check-in form supports:
+1. Input mode selection (form/voice/both)
+2. Prefill from voice-collected data
+3. UI sync when using voice mode
+"""
+
+import pytest
+from pathlib import Path
+
+
+class TestCheckInModalStructure:
+    """Test that CheckInModal has voice support features."""
+
+    @pytest.fixture
+    def modal_content(self) -> str:
+        """Get CheckInModal component content."""
+        modal_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "sidebar"
+            / "CheckInModal.tsx"
+        )
+        return modal_path.read_text()
+
+    def test_has_input_mode_type(self, modal_content: str) -> None:
+        """Should export InputMode type for form/voice/both."""
+        assert 'export type InputMode = "form" | "voice" | "both"' in modal_content
+
+    def test_has_prefill_data_prop(self, modal_content: str) -> None:
+        """Should accept prefillData prop for voice-collected data."""
+        assert "prefillData" in modal_content
+        assert "Partial<SessionContext>" in modal_content
+
+    def test_has_input_mode_change_callback(self, modal_content: str) -> None:
+        """Should have callback for input mode changes."""
+        assert "onInputModeChange" in modal_content
+
+    def test_has_voice_available_prop(self, modal_content: str) -> None:
+        """Should accept voiceAvailable prop to disable voice options."""
+        assert "voiceAvailable" in modal_content
+
+
+class TestInputModeOptions:
+    """Test input mode selector configuration."""
+
+    @pytest.fixture
+    def modal_content(self) -> str:
+        """Get CheckInModal component content."""
+        modal_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "sidebar"
+            / "CheckInModal.tsx"
+        )
+        return modal_path.read_text()
+
+    def test_has_form_mode_option(self, modal_content: str) -> None:
+        """Should have form-only input mode."""
+        assert 'value: "form"' in modal_content
+        assert 'label: "Form"' in modal_content
+
+    def test_has_voice_mode_option(self, modal_content: str) -> None:
+        """Should have voice-only input mode."""
+        assert 'value: "voice"' in modal_content
+        assert 'label: "Voice"' in modal_content
+
+    def test_has_both_mode_option(self, modal_content: str) -> None:
+        """Should have combined voice+form input mode."""
+        assert 'value: "both"' in modal_content
+        assert 'label: "Both"' in modal_content
+
+
+class TestVoiceModeUI:
+    """Test voice mode user interface."""
+
+    @pytest.fixture
+    def modal_content(self) -> str:
+        """Get CheckInModal component content."""
+        modal_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "sidebar"
+            / "CheckInModal.tsx"
+        )
+        return modal_path.read_text()
+
+    def test_shows_voice_hint_in_voice_mode(self, modal_content: str) -> None:
+        """Should show voice input hint when in voice/both mode."""
+        assert "showVoiceHint" in modal_content
+        assert 'Try saying:' in modal_content
+
+    def test_hides_form_in_voice_only_mode(self, modal_content: str) -> None:
+        """Should conditionally show form based on mode."""
+        assert "showForm" in modal_content
+        assert 'inputMode === "form" || inputMode === "both"' in modal_content
+
+    def test_voice_only_mode_has_close_option(self, modal_content: str) -> None:
+        """Should allow closing modal in voice-only mode to start chatting."""
+        assert "Close and start chatting" in modal_content
+
+
+class TestPrefillDataSync:
+    """Test that form syncs with prefill data from voice."""
+
+    @pytest.fixture
+    def modal_content(self) -> str:
+        """Get CheckInModal component content."""
+        modal_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "sidebar"
+            / "CheckInModal.tsx"
+        )
+        return modal_path.read_text()
+
+    def test_syncs_time_available_from_prefill(self, modal_content: str) -> None:
+        """Should update timeAvailable when prefillData changes."""
+        assert "prefillData.timeAvailable" in modal_content
+        assert "setTimeAvailable(prefillData.timeAvailable)" in modal_content
+
+    def test_syncs_energy_level_from_prefill(self, modal_content: str) -> None:
+        """Should update energyLevel when prefillData changes."""
+        assert "prefillData.energyLevel" in modal_content
+        assert "setEnergyLevel(prefillData.energyLevel)" in modal_content
+
+    def test_syncs_mindset_from_prefill(self, modal_content: str) -> None:
+        """Should update mindset when prefillData changes."""
+        assert "prefillData.mindset" in modal_content
+        assert "setMindset(prefillData.mindset)" in modal_content
+
+    def test_uses_effect_for_sync(self, modal_content: str) -> None:
+        """Should use useEffect to sync prefill data."""
+        assert "useEffect" in modal_content
+        assert "[prefillData]" in modal_content
+
+
+class TestAccessibility:
+    """Test accessibility features in voice-enabled check-in."""
+
+    @pytest.fixture
+    def modal_content(self) -> str:
+        """Get CheckInModal component content."""
+        modal_path = (
+            Path(__file__).parent.parent
+            / "web"
+            / "components"
+            / "sidebar"
+            / "CheckInModal.tsx"
+        )
+        return modal_path.read_text()
+
+    def test_input_mode_buttons_have_aria_pressed(self, modal_content: str) -> None:
+        """Input mode buttons should have aria-pressed for screen readers."""
+        assert 'aria-pressed={inputMode === option.value}' in modal_content
+
+    def test_close_button_has_aria_label(self, modal_content: str) -> None:
+        """Close button should have aria-label."""
+        assert 'aria-label="Close"' in modal_content
+
+    def test_slider_has_aria_attributes(self, modal_content: str) -> None:
+        """Energy slider should have proper ARIA attributes."""
+        assert "aria-valuemin" in modal_content
+        assert "aria-valuemax" in modal_content
+        assert "aria-valuenow" in modal_content
+
+    def test_voice_unavailable_disables_options(self, modal_content: str) -> None:
+        """Voice options should be disabled when voice is unavailable."""
+        assert 'option.value !== "form" && !voiceAvailable' in modal_content
+        assert "cursor-not-allowed" in modal_content
+
+
+class TestBackendIntentSupport:
+    """Test that backend supports check-in intent extraction."""
+
+    def test_session_check_in_intent_schema_exists(self) -> None:
+        """Backend should have session_check_in intent schema."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "intent_extractor",
+            Path(__file__).parent.parent
+            / "src"
+            / "sage"
+            / "orchestration"
+            / "intent_extractor.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert "session_check_in" in module.INTENT_SCHEMAS
+
+    def test_check_in_schema_has_required_fields(self) -> None:
+        """Check-in schema should include timeAvailable, energyLevel, mindset."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "intent_extractor",
+            Path(__file__).parent.parent
+            / "src"
+            / "sage"
+            / "orchestration"
+            / "intent_extractor.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        schema = module.INTENT_SCHEMAS["session_check_in"]
+        optional_fields = schema.get("optional", [])
+
+        assert "timeAvailable" in optional_fields
+        assert "energyLevel" in optional_fields
+        assert "mindset" in optional_fields

--- a/web/components/sidebar/CheckInModal.tsx
+++ b/web/components/sidebar/CheckInModal.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import { useState } from "react";
+/**
+ * CheckInModal - Session check-in for gathering learner context
+ *
+ * Updated for #59 - Voice mode and dual input support
+ */
+
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Zap, Target, Waves, ArrowRight } from "lucide-react";
+import { X, Zap, Target, Waves, ArrowRight, Mic, MousePointer, Combine } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SessionContext } from "@/types";
+
+export type InputMode = "form" | "voice" | "both";
 
 export interface CheckInModalProps {
   isOpen: boolean;
   onClose: () => void;
   onComplete: (context: SessionContext) => void;
+  /** Prefill data from voice input */
+  prefillData?: Partial<SessionContext>;
+  /** Callback when input mode changes */
+  onInputModeChange?: (mode: InputMode) => void;
+  /** Whether voice is currently available */
+  voiceAvailable?: boolean;
 }
 
 type TimeOption = SessionContext["timeAvailable"];
@@ -27,18 +41,73 @@ const timeOptions: TimeOptionConfig[] = [
   { value: "deep", label: "Deep", duration: "open-ended", icon: <Waves className="h-5 w-5" /> },
 ];
 
+interface InputModeOption {
+  value: InputMode;
+  label: string;
+  description: string;
+  icon: JSX.Element;
+}
+
+const inputModeOptions: InputModeOption[] = [
+  {
+    value: "form",
+    label: "Form",
+    description: "Fill in the form below",
+    icon: <MousePointer className="h-4 w-4" />,
+  },
+  {
+    value: "voice",
+    label: "Voice",
+    description: "Tell me conversationally",
+    icon: <Mic className="h-4 w-4" />,
+  },
+  {
+    value: "both",
+    label: "Both",
+    description: "Use voice and form together",
+    icon: <Combine className="h-4 w-4" />,
+  },
+];
+
 export function CheckInModal({
   isOpen,
   onClose,
   onComplete,
+  prefillData,
+  onInputModeChange,
+  voiceAvailable = true,
 }: CheckInModalProps): JSX.Element {
+  const [inputMode, setInputMode] = useState<InputMode>("form");
   const [timeAvailable, setTimeAvailable] = useState<TimeOption>("focused");
   const [energyLevel, setEnergyLevel] = useState(50);
   const [mindset, setMindset] = useState("");
 
+  // Sync form state with prefill data from voice
+  useEffect(() => {
+    if (prefillData) {
+      if (prefillData.timeAvailable) {
+        setTimeAvailable(prefillData.timeAvailable);
+      }
+      if (prefillData.energyLevel !== undefined) {
+        setEnergyLevel(prefillData.energyLevel);
+      }
+      if (prefillData.mindset) {
+        setMindset(prefillData.mindset);
+      }
+    }
+  }, [prefillData]);
+
+  const handleInputModeChange = (mode: InputMode) => {
+    setInputMode(mode);
+    onInputModeChange?.(mode);
+  };
+
   const handleSubmit = () => {
     onComplete({ timeAvailable, energyLevel, mindset });
   };
+
+  const showForm = inputMode === "form" || inputMode === "both";
+  const showVoiceHint = inputMode === "voice" || inputMode === "both";
 
   return (
     <AnimatePresence>
@@ -62,6 +131,7 @@ export function CheckInModal({
               <button
                 onClick={onClose}
                 className="absolute top-4 right-4 p-2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                aria-label="Close"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -76,70 +146,142 @@ export function CheckInModal({
                   </p>
                 </div>
 
+                {/* Input Mode Selector */}
                 <div className="space-y-2">
                   <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                    Time available
+                    How would you like to check in?
                   </label>
-                  <div className="grid grid-cols-3 gap-3">
-                    {timeOptions.map((option) => (
-                      <button
-                        key={option.value}
-                        onClick={() => setTimeAvailable(option.value)}
-                        className={cn(
-                          "flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-all",
-                          timeAvailable === option.value
-                            ? "border-sage-500 bg-sage-50 dark:bg-sage-900/20 text-sage-700 dark:text-sage-300"
-                            : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
-                        )}
+                  <div className="grid grid-cols-3 gap-2">
+                    {inputModeOptions.map((option) => {
+                      const isDisabled = option.value !== "form" && !voiceAvailable;
+                      return (
+                        <button
+                          key={option.value}
+                          onClick={() => handleInputModeChange(option.value)}
+                          disabled={isDisabled}
+                          className={cn(
+                            "flex flex-col items-center gap-1 p-2 rounded-lg border transition-all text-sm",
+                            inputMode === option.value
+                              ? "border-sage-500 bg-sage-50 dark:bg-sage-900/20 text-sage-700 dark:text-sage-300"
+                              : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600",
+                            isDisabled && "opacity-50 cursor-not-allowed"
+                          )}
+                          aria-pressed={inputMode === option.value}
+                        >
+                          {option.icon}
+                          <span className="font-medium">{option.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Voice hint when in voice/both mode */}
+                {showVoiceHint && (
+                  <div className="p-3 bg-sage-50 dark:bg-sage-900/20 rounded-lg border border-sage-200 dark:border-sage-800">
+                    <p className="text-sm text-sage-700 dark:text-sage-300">
+                      <Mic className="h-4 w-4 inline mr-2" />
+                      Try saying: &quot;I have about 30 minutes, feeling pretty tired, have a presentation tomorrow&quot;
+                    </p>
+                  </div>
+                )}
+
+                {/* Form fields - shown in form/both mode */}
+                {showForm && (
+                  <>
+                    <div className="space-y-2">
+                      <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                        Time available
+                      </label>
+                      <div className="grid grid-cols-3 gap-3">
+                        {timeOptions.map((option) => (
+                          <button
+                            key={option.value}
+                            onClick={() => setTimeAvailable(option.value)}
+                            className={cn(
+                              "flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-all",
+                              timeAvailable === option.value
+                                ? "border-sage-500 bg-sage-50 dark:bg-sage-900/20 text-sage-700 dark:text-sage-300"
+                                : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
+                            )}
+                            aria-pressed={timeAvailable === option.value}
+                          >
+                            {option.icon}
+                            <span className="text-sm font-medium">{option.label}</span>
+                            <span className="text-xs text-slate-500 dark:text-slate-400">
+                              {option.duration}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="energy-slider"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300"
                       >
-                        {option.icon}
-                        <span className="text-sm font-medium">{option.label}</span>
-                        <span className="text-xs text-slate-500 dark:text-slate-400">
-                          {option.duration}
-                        </span>
-                      </button>
-                    ))}
+                        Energy level
+                      </label>
+                      <div className="flex items-center gap-3">
+                        <span className="text-lg" aria-hidden="true">😴</span>
+                        <input
+                          id="energy-slider"
+                          type="range"
+                          min="0"
+                          max="100"
+                          value={energyLevel}
+                          onChange={(e) => setEnergyLevel(parseInt(e.target.value))}
+                          className="flex-1 h-2 bg-slate-200 dark:bg-slate-700 rounded-full appearance-none cursor-pointer accent-sage-500"
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-valuenow={energyLevel}
+                        />
+                        <span className="text-lg" aria-hidden="true">🔥</span>
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <label
+                        htmlFor="mindset-input"
+                        className="block text-sm font-medium text-slate-700 dark:text-slate-300"
+                      >
+                        Anything on your mind?
+                      </label>
+                      <textarea
+                        id="mindset-input"
+                        value={mindset}
+                        onChange={(e) => setMindset(e.target.value)}
+                        placeholder="e.g., Have a pricing call tomorrow, feeling nervous"
+                        rows={2}
+                        className="w-full px-4 py-3 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent resize-none"
+                      />
+                    </div>
+
+                    <button
+                      onClick={handleSubmit}
+                      className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-sage-600 hover:bg-sage-700 text-white font-medium rounded-xl transition-colors"
+                    >
+                      Let&apos;s begin
+                      <ArrowRight className="h-4 w-4" />
+                    </button>
+                  </>
+                )}
+
+                {/* Voice-only mode message */}
+                {inputMode === "voice" && (
+                  <div className="text-center py-4">
+                    <p className="text-slate-600 dark:text-slate-400">
+                      Just start talking! I&apos;ll gather your check-in through our conversation.
+                    </p>
+                    <button
+                      onClick={onClose}
+                      className="mt-4 px-6 py-2 text-sage-600 dark:text-sage-400 hover:underline"
+                    >
+                      Close and start chatting
+                    </button>
                   </div>
-                </div>
-
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                    Energy level
-                  </label>
-                  <div className="flex items-center gap-3">
-                    <span className="text-lg">😴</span>
-                    <input
-                      type="range"
-                      min="0"
-                      max="100"
-                      value={energyLevel}
-                      onChange={(e) => setEnergyLevel(parseInt(e.target.value))}
-                      className="flex-1 h-2 bg-slate-200 dark:bg-slate-700 rounded-full appearance-none cursor-pointer accent-sage-500"
-                    />
-                    <span className="text-lg">🔥</span>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                    Anything on your mind?
-                  </label>
-                  <textarea
-                    value={mindset}
-                    onChange={(e) => setMindset(e.target.value)}
-                    placeholder="e.g., Have a pricing call tomorrow, feeling nervous"
-                    rows={2}
-                    className="w-full px-4 py-3 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent resize-none"
-                  />
-                </div>
-
-                <button
-                  onClick={handleSubmit}
-                  className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-sage-600 hover:bg-sage-700 text-white font-medium rounded-xl transition-colors"
-                >
-                  Let&apos;s begin
-                  <ArrowRight className="h-4 w-4" />
-                </button>
+                )}
               </div>
             </div>
           </motion.div>

--- a/web/components/sidebar/index.ts
+++ b/web/components/sidebar/index.ts
@@ -8,4 +8,4 @@ export type { ProgressBarProps } from "./ProgressBar";
 export type { CurrentGoalProps } from "./CurrentGoal";
 export type { KnowledgeStatsProps } from "./KnowledgeStats";
 export type { UpcomingApplicationsProps } from "./UpcomingApplications";
-export type { CheckInModalProps } from "./CheckInModal";
+export type { CheckInModalProps, InputMode } from "./CheckInModal";


### PR DESCRIPTION
## Summary

Enable check-in form to work with voice mode and support dual input methods.

### New Features
- **Input mode selector**: Form / Voice / Both
- **Prefill data sync**: Form fields populate from voice-collected data
- **Voice hints**: Example phrases when in voice/both mode
- **Voice-only mode**: Streamlined UI with close option to start chatting

### Props Added
- `prefillData`: `Partial<SessionContext>` - populate form from voice
- `onInputModeChange`: Callback for input mode changes
- `voiceAvailable`: Disable voice options when unavailable

### Accessibility
- `aria-pressed` on mode selector buttons
- `aria-label` on close button
- ARIA attributes on energy slider

### Tests
20 tests covering:
- Modal structure and voice support features
- Input mode options (form/voice/both)
- Voice mode UI behavior
- Prefill data synchronization
- Accessibility features
- Backend intent support

## Test Plan
- [x] TypeScript compiles
- [x] All 20 tests pass
- [ ] Manual test: mode selector works
- [ ] Manual test: voice hint appears in voice/both mode

Closes #59