### PR TITLE
Fix voice check-in to create session (Issue #120)

### DIFF
--- a/web/components/sidebar/CheckInModal.tsx
+++ b/web/components/sidebar/CheckInModal.tsx
@@ -294,10 +294,16 @@ export function CheckInModal({
                       Just start talking! I&apos;ll gather your check-in through our conversation.
                     </p>
                     <button
-                      onClick={onClose}
-                      className="mt-4 px-6 py-2 text-sage-600 dark:text-sage-400 hover:underline"
+                      onClick={handleSubmit}
+                      disabled={isLoading}
+                      className={cn(
+                        "mt-4 px-6 py-2 rounded-lg transition-colors",
+                        isLoading
+                          ? "text-sage-400 cursor-not-allowed"
+                          : "text-sage-600 dark:text-sage-400 hover:bg-sage-50 dark:hover:bg-sage-900/20"
+                      )}
                     >
-                      Close and start chatting
+                      {isLoading ? "Starting session..." : "Close and start chatting"}
                     </button>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Fixed 'Close and start chatting' button to create session instead of just closing modal
- Changed `onClick={onClose}` to `onClick={handleSubmit}` to trigger session creation
- Added loading state and disabled state to match form mode behavior

## Root Cause
The voice check-in button was calling `onClose` which only closed the modal.
The form check-in button calls `handleSubmit` → `onComplete(context)` → creates session via API.

## Test plan
- [x] TypeScript compiles without errors
- [ ] Manual test: Select Voice check-in, click 'Close and start chatting'
- [ ] Verify WebSocket connects and shows 'Connected'
- [ ] Verify chat input is enabled