### PR TITLE
feat: Replace modal forms with inline chat feed forms (Issue #121)

### DIFF
--- a/web/components/chat/InlineCheckIn.tsx
+++ b/web/components/chat/InlineCheckIn.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * InlineCheckIn - Session check-in form rendered inline in the chat feed
+ *
+ * Replaces modal-based check-in for better conversation flow.
+ * Appears as a SAGE message with an embedded form.
+ */
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Zap, Target, Waves, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SessionContext } from "@/types";
+
+type TimeOption = SessionContext["timeAvailable"];
+
+interface TimeOptionConfig {
+  value: TimeOption;
+  label: string;
+  duration: string;
+  icon: JSX.Element;
+}
+
+const timeOptions: TimeOptionConfig[] = [
+  { value: "quick", label: "Quick", duration: "15 min", icon: <Zap className="h-5 w-5" /> },
+  { value: "focused", label: "Focused", duration: "45 min", icon: <Target className="h-5 w-5" /> },
+  { value: "deep", label: "Deep", duration: "open-ended", icon: <Waves className="h-5 w-5" /> },
+];
+
+export interface InlineCheckInProps {
+  onComplete: (context: SessionContext) => void;
+  isLoading?: boolean;
+}
+
+export function InlineCheckIn({
+  onComplete,
+  isLoading = false,
+}: InlineCheckInProps): JSX.Element {
+  const [timeAvailable, setTimeAvailable] = useState<TimeOption>("focused");
+  const [energyLevel, setEnergyLevel] = useState(50);
+  const [mindset, setMindset] = useState("");
+
+  const handleSubmit = () => {
+    onComplete({ timeAvailable, energyLevel, mindset });
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className="flex w-full justify-start"
+    >
+      <div className="max-w-[85%] rounded-2xl px-4 py-3 bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-bl-md">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xs font-semibold text-sage-600 dark:text-sage-400">
+            SAGE
+          </span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            Check-in
+          </span>
+        </div>
+
+        <div className="space-y-4">
+          <p className="text-sm">
+            How are you showing up today? This helps me tailor our session.
+          </p>
+
+          {/* Time Available */}
+          <div className="space-y-2">
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Time available
+            </label>
+            <div className="grid grid-cols-3 gap-2">
+              {timeOptions.map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => setTimeAvailable(option.value)}
+                  disabled={isLoading}
+                  className={cn(
+                    "flex flex-col items-center gap-1 p-2 rounded-lg border transition-all text-xs",
+                    timeAvailable === option.value
+                      ? "border-sage-500 bg-sage-50 dark:bg-sage-900/30 text-sage-700 dark:text-sage-300"
+                      : "border-slate-200 dark:border-slate-600 hover:border-slate-300 dark:hover:border-slate-500"
+                  )}
+                  aria-pressed={timeAvailable === option.value}
+                >
+                  {option.icon}
+                  <span className="font-medium">{option.label}</span>
+                  <span className="text-slate-500 dark:text-slate-400">
+                    {option.duration}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Energy Level */}
+          <div className="space-y-2">
+            <label
+              htmlFor="inline-energy-slider"
+              className="block text-xs font-medium text-slate-600 dark:text-slate-400"
+            >
+              Energy level
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-sm" aria-hidden="true">😴</span>
+              <input
+                id="inline-energy-slider"
+                type="range"
+                min="0"
+                max="100"
+                value={energyLevel}
+                onChange={(e) => setEnergyLevel(parseInt(e.target.value))}
+                disabled={isLoading}
+                className="flex-1 h-2 bg-slate-200 dark:bg-slate-700 rounded-full appearance-none cursor-pointer accent-sage-500"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={energyLevel}
+              />
+              <span className="text-sm" aria-hidden="true">🔥</span>
+            </div>
+          </div>
+
+          {/* Mindset */}
+          <div className="space-y-2">
+            <label
+              htmlFor="inline-mindset-input"
+              className="block text-xs font-medium text-slate-600 dark:text-slate-400"
+            >
+              Anything on your mind? (optional)
+            </label>
+            <textarea
+              id="inline-mindset-input"
+              value={mindset}
+              onChange={(e) => setMindset(e.target.value)}
+              placeholder="e.g., Have a meeting tomorrow, feeling nervous"
+              rows={2}
+              disabled={isLoading}
+              className="w-full px-3 py-2 bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sage-500 focus:border-transparent resize-none disabled:opacity-50"
+            />
+          </div>
+
+          {/* Submit Button */}
+          <button
+            onClick={handleSubmit}
+            disabled={isLoading}
+            className={cn(
+              "w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors",
+              isLoading
+                ? "bg-sage-400 cursor-not-allowed"
+                : "bg-sage-600 hover:bg-sage-700",
+              "text-white"
+            )}
+          >
+            {isLoading ? (
+              <>
+                <div className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                Starting session...
+              </>
+            ) : (
+              <>
+                Let&apos;s begin
+                <ArrowRight className="h-4 w-4" />
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/web/components/chat/InlinePracticeSetup.tsx
+++ b/web/components/chat/InlinePracticeSetup.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+/**
+ * InlinePracticeSetup - Practice scenario selector rendered inline in the chat feed
+ *
+ * Replaces modal-based scenario selection for better conversation flow.
+ * Appears as a SAGE message with scenario options.
+ */
+
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { Theater, MessageSquare, DollarSign, Users, Presentation, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api";
+import type { Scenario } from "@/types";
+import type { PracticeScenario } from "@/components/practice/PracticeModeContainer";
+
+export interface InlinePracticeSetupProps {
+  onStart: (scenario: PracticeScenario) => void;
+  onCancel: () => void;
+  suggestedScenario?: string;
+}
+
+const SCENARIO_ICONS: Record<string, typeof DollarSign> = {
+  "pricing-call": DollarSign,
+  "pricing": DollarSign,
+  "negotiation": Users,
+  "presentation": Presentation,
+  "interview": MessageSquare,
+  "sales": DollarSign,
+};
+
+function getScenarioIcon(scenario: Scenario): typeof DollarSign {
+  if (SCENARIO_ICONS[scenario.id]) return SCENARIO_ICONS[scenario.id];
+  if (scenario.category && SCENARIO_ICONS[scenario.category]) {
+    return SCENARIO_ICONS[scenario.category];
+  }
+  return MessageSquare;
+}
+
+function toFrontendScenario(scenario: Scenario): PracticeScenario {
+  return {
+    id: scenario.id,
+    title: scenario.title,
+    description: scenario.description || "Practice scenario",
+    sageRole: scenario.sage_role,
+    userRole: scenario.user_role,
+  };
+}
+
+export function InlinePracticeSetup({
+  onStart,
+  onCancel,
+  suggestedScenario,
+}: InlinePracticeSetupProps): JSX.Element {
+  const [scenarios, setScenarios] = useState<Scenario[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [customScenario, setCustomScenario] = useState("");
+  const [customRole, setCustomRole] = useState("");
+  const [showCustom, setShowCustom] = useState(false);
+
+  useEffect(() => {
+    const fetchScenarios = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await api.listScenarios(true);
+        setScenarios(response.scenarios);
+      } catch {
+        try {
+          const presetsResponse = await api.listPresetScenarios();
+          setScenarios(presetsResponse.scenarios);
+        } catch {
+          setError("Failed to load scenarios");
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchScenarios();
+  }, []);
+
+  const handleCustomStart = () => {
+    if (!customScenario.trim()) return;
+
+    const scenario: PracticeScenario = {
+      id: `custom-${Date.now()}`,
+      title: customScenario,
+      description: "Custom practice scenario",
+      sageRole: customRole || "The other party",
+      userRole: "You",
+    };
+    onStart(scenario);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className="flex w-full justify-start"
+    >
+      <div className="max-w-[85%] rounded-2xl px-4 py-3 bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-bl-md">
+        <div className="flex items-center gap-2 mb-3">
+          <Theater className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+          <span className="text-xs font-semibold text-amber-600 dark:text-amber-400">
+            Practice Mode
+          </span>
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-sm">
+            Time to practice! Choose a scenario to rehearse, or create your own.
+          </p>
+
+          {suggestedScenario && (
+            <div className="p-2 rounded-lg bg-sage-50 dark:bg-sage-900/30 border border-sage-200 dark:border-sage-800">
+              <p className="text-xs text-sage-700 dark:text-sage-300">
+                Suggested: <strong>{suggestedScenario}</strong>
+              </p>
+            </div>
+          )}
+
+          {!showCustom ? (
+            <>
+              {isLoading && (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="w-5 h-5 text-amber-500 animate-spin" />
+                  <span className="ml-2 text-sm text-slate-500">Loading scenarios...</span>
+                </div>
+              )}
+
+              {error && (
+                <div className="py-2 text-center text-sm text-red-500 dark:text-red-400">
+                  {error}
+                </div>
+              )}
+
+              {!isLoading && !error && scenarios.length > 0 && (
+                <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto">
+                  {scenarios.slice(0, 6).map((scenario) => {
+                    const Icon = getScenarioIcon(scenario);
+                    return (
+                      <button
+                        key={scenario.id}
+                        onClick={() => onStart(toFrontendScenario(scenario))}
+                        className={cn(
+                          "flex flex-col items-start p-2 rounded-lg border text-left text-xs",
+                          "border-slate-200 dark:border-slate-600",
+                          "hover:border-amber-400 dark:hover:border-amber-500",
+                          "hover:bg-amber-50 dark:hover:bg-amber-900/20",
+                          "transition-all"
+                        )}
+                      >
+                        <div className="flex items-center gap-1.5 mb-1">
+                          <Icon className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+                          {!scenario.is_preset && (
+                            <span className="text-[9px] px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-400">
+                              Custom
+                            </span>
+                          )}
+                        </div>
+                        <span className="font-medium text-slate-900 dark:text-white line-clamp-1">
+                          {scenario.title}
+                        </span>
+                        <span className="text-slate-500 dark:text-slate-400 mt-0.5 line-clamp-1">
+                          {scenario.description || `Play: ${scenario.user_role}`}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {!isLoading && !error && scenarios.length === 0 && (
+                <div className="py-4 text-center text-sm text-slate-500">
+                  No scenarios available. Create a custom one below.
+                </div>
+              )}
+
+              <div className="flex gap-2 pt-2">
+                <button
+                  onClick={() => setShowCustom(true)}
+                  className="flex-1 py-1.5 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 rounded-lg transition-colors"
+                >
+                  Create custom scenario
+                </button>
+                <button
+                  onClick={onCancel}
+                  className="px-3 py-1.5 text-xs text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                  What do you want to practice?
+                </label>
+                <input
+                  type="text"
+                  value={customScenario}
+                  onChange={(e) => setCustomScenario(e.target.value)}
+                  placeholder="e.g., Asking for a raise"
+                  className={cn(
+                    "w-full px-3 py-2 rounded-lg text-sm",
+                    "bg-white dark:bg-slate-700",
+                    "text-slate-900 dark:text-white",
+                    "placeholder:text-slate-400",
+                    "border border-slate-200 dark:border-slate-600",
+                    "focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  )}
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+                  Who should SAGE play? (optional)
+                </label>
+                <input
+                  type="text"
+                  value={customRole}
+                  onChange={(e) => setCustomRole(e.target.value)}
+                  placeholder="e.g., Your manager"
+                  className={cn(
+                    "w-full px-3 py-2 rounded-lg text-sm",
+                    "bg-white dark:bg-slate-700",
+                    "text-slate-900 dark:text-white",
+                    "placeholder:text-slate-400",
+                    "border border-slate-200 dark:border-slate-600",
+                    "focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  )}
+                />
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowCustom(false)}
+                  className="flex-1 py-1.5 text-xs rounded-lg text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={handleCustomStart}
+                  disabled={!customScenario.trim()}
+                  className={cn(
+                    "flex-1 py-1.5 text-xs rounded-lg font-medium transition-colors",
+                    customScenario.trim()
+                      ? "bg-amber-500 text-white hover:bg-amber-600"
+                      : "bg-slate-200 dark:bg-slate-700 text-slate-400 cursor-not-allowed"
+                  )}
+                >
+                  Start Practice
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/web/components/chat/index.ts
+++ b/web/components/chat/index.ts
@@ -5,6 +5,8 @@ export { EmptyState } from "./EmptyState";
 export { MarkdownContent } from "./MarkdownContent";
 export { MermaidDiagram } from "./MermaidDiagram";
 export { GeneratedImage } from "./GeneratedImage";
+export { InlineCheckIn } from "./InlineCheckIn";
+export { InlinePracticeSetup } from "./InlinePracticeSetup";
 
 export type { MessageBubbleProps } from "./MessageBubble";
 export type { ChatInputProps } from "./ChatInput";
@@ -13,3 +15,5 @@ export type { EmptyStateProps } from "./EmptyState";
 export type { MarkdownContentProps } from "./MarkdownContent";
 export type { MermaidDiagramProps } from "./MermaidDiagram";
 export type { GeneratedImageProps } from "./GeneratedImage";
+export type { InlineCheckInProps } from "./InlineCheckIn";
+export type { InlinePracticeSetupProps } from "./InlinePracticeSetup";


### PR DESCRIPTION
## Summary
- Replace modal-based check-in and practice setup forms with inline versions that appear in the chat feed
- Creates a more natural conversation flow where forms are part of the chat
- Better UX on mobile without modal dismiss issues

## Test plan
- [ ] Visit /chat page as logged-in user
- [ ] Verify check-in form appears inline in the chat feed (not as modal overlay)
- [ ] Complete check-in and verify session starts
- [ ] Click Practice button in header
- [ ] Verify practice setup appears inline in the chat feed
- [ ] Select a scenario and verify practice mode starts
- [ ] Verify practice feedback modal still works (intentionally kept as modal)

Closes #121