### PR TITLE
Fix authentication: HKDF key derivation and cookie auth support

### DIFF
--- a/src/sage/api/auth.py
+++ b/src/sage/api/auth.py
@@ -1,14 +1,36 @@
 """Authentication utilities for SAGE API."""
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from jose.jwe import decrypt as jwe_decrypt, JWEError
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from jose import jwe
 from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from sage.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _derive_nextauth_key(secret: str) -> bytes:
+    """Derive encryption key from NextAuth secret using HKDF.
+
+    NextAuth v4 derives its JWE encryption key using HKDF with:
+    - Empty salt
+    - Info string: "NextAuth.js Generated Encryption Key"
+    - 32 bytes output (256 bits for A256GCM)
+    """
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,  # 32 bytes for A256GCM
+        salt=b"",  # Empty salt for NextAuth v4
+        info=b"NextAuth.js Generated Encryption Key",
+    )
+    return hkdf.derive(secret.encode("utf-8"))
 
 
 @dataclass
@@ -44,21 +66,30 @@ class JWTBearer(HTTPBearer):
         return self._settings
 
     async def __call__(self, request: Request) -> Optional[CurrentUser]:
-        credentials: Optional[HTTPAuthorizationCredentials] = await super().__call__(
-            request
-        )
-        if not credentials:
-            if self.auto_error:
-                raise _auth_error("Not authenticated")
-            return None
+        # First try Authorization header
+        auth_header = request.headers.get("Authorization", "")
 
-        return self._verify_token(credentials.credentials)
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header[7:]  # Strip "Bearer " prefix
+            return self._verify_token(token)
+
+        # Fall back to NextAuth session cookie (httpOnly cookie can't be read by JS)
+        # NextAuth uses "next-auth.session-token" or "__Secure-next-auth.session-token"
+        token = request.cookies.get("next-auth.session-token")
+        if not token:
+            token = request.cookies.get("__Secure-next-auth.session-token")
+
+        if token:
+            return self._verify_token(token)
+        if self.auto_error:
+            raise _auth_error("Not authenticated")
+        return None
 
     def _verify_token(self, token: str) -> CurrentUser:
         """Verify encrypted JWT (JWE) from NextAuth and extract user context.
 
-        NextAuth encrypts JWT tokens using JWE (JSON Web Encryption) by default.
-        We decrypt using the same NEXTAUTH_SECRET that NextAuth uses for encryption.
+        NextAuth v4 encrypts JWT tokens using JWE (JSON Web Encryption).
+        The encryption key is derived from NEXTAUTH_SECRET using HKDF.
         """
         if not self.settings.nextauth_secret:
             raise HTTPException(
@@ -67,8 +98,9 @@ class JWTBearer(HTTPBearer):
             )
 
         try:
-            secret = self.settings.nextauth_secret.encode("utf-8")
-            decrypted = jwe_decrypt(token, secret)
+            # Derive the encryption key using HKDF (same as NextAuth v4)
+            derived_key = _derive_nextauth_key(self.settings.nextauth_secret)
+            decrypted = jwe.decrypt(token, derived_key)
             payload = json.loads(decrypted)
 
             # Validate required claims
@@ -84,13 +116,16 @@ class JWTBearer(HTTPBearer):
                 name=payload.get("name"),
             )
 
-        except JWEError as e:
+        except jwe.JWEError as e:
+            logger.error(f"JWE decryption failed: {e}")
             raise _auth_error(f"Token decryption failed: {e}")
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logger.error(f"JSON decode failed: {e}")
             raise _auth_error("Invalid token payload")
         except HTTPException:
             raise
         except Exception as e:
+            logger.error(f"Auth exception: {type(e).__name__}: {e}")
             raise _auth_error(f"Authentication failed: {e}")
 
 
@@ -112,9 +147,18 @@ async def get_current_user_optional(request: Request) -> Optional[CurrentUser]:
 async def get_current_user_ws(websocket: WebSocket) -> CurrentUser:
     """Extract user from WebSocket connection.
 
-    WebSocket auth comes from query parameter: ?token=xxx
+    WebSocket auth supports:
+    1. Query parameter: ?token=xxx
+    2. Session cookies (httpOnly cookies from NextAuth)
     """
+    # First try query parameter
     token = websocket.query_params.get("token")
+
+    # Fall back to NextAuth session cookies
+    if not token:
+        token = websocket.cookies.get("next-auth.session-token")
+    if not token:
+        token = websocket.cookies.get("__Secure-next-auth.session-token")
 
     if not token:
         await websocket.close(code=4001, reason="Authentication required")

--- a/web/app/api/ws-token/route.ts
+++ b/web/app/api/ws-token/route.ts
@@ -1,0 +1,26 @@
+/**
+ * API route to get the session token for WebSocket authentication.
+ *
+ * WebSocket connections can't send httpOnly cookies cross-origin,
+ * so the frontend needs to fetch the token from this endpoint
+ * and pass it as a query parameter.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  // Get the session token from cookies
+  const token =
+    request.cookies.get("next-auth.session-token")?.value ||
+    request.cookies.get("__Secure-next-auth.session-token")?.value;
+
+  if (!token) {
+    return NextResponse.json(
+      { error: "Not authenticated" },
+      { status: 401 }
+    );
+  }
+
+  // Return the token for WebSocket use
+  return NextResponse.json({ token });
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -31,12 +31,13 @@ export const config = {
   matcher: [
     /*
      * Match all paths except:
-     * - api/auth (NextAuth routes need to be accessible)
+     * - api/* (all API routes - NextAuth and proxied backend routes)
+     *   Backend handles its own auth via Authorization header
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico
      * - public files (images, etc.)
      */
-    "/((?!api/auth|_next/static|_next/image|favicon.ico|.*\\.png$|.*\\.svg$).*)",
+    "/((?!api/|_next/static|_next/image|favicon.ico|.*\\.png$|.*\\.svg$).*)",
   ],
 };

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -4,9 +4,18 @@ const nextConfig = {
     return {
       beforeFiles: [
         // Proxy API requests to backend, EXCEPT NextAuth routes
+        // Note: Need both exact paths and wildcard paths for proper routing
+        {
+          source: "/api/learners",
+          destination: "http://localhost:8000/api/learners",
+        },
         {
           source: "/api/learners/:path*",
           destination: "http://localhost:8000/api/learners/:path*",
+        },
+        {
+          source: "/api/sessions",
+          destination: "http://localhost:8000/api/sessions",
         },
         {
           source: "/api/sessions/:path*",
@@ -25,8 +34,16 @@ const nextConfig = {
           destination: "http://localhost:8000/api/voice/:path*",
         },
         {
+          source: "/api/scenarios",
+          destination: "http://localhost:8000/api/scenarios",
+        },
+        {
           source: "/api/scenarios/:path*",
           destination: "http://localhost:8000/api/scenarios/:path*",
+        },
+        {
+          source: "/api/graph/:path*",
+          destination: "http://localhost:8000/api/graph/:path*",
         },
         // Backend auth endpoints (login, register, sync) - NOT NextAuth
         {


### PR DESCRIPTION
## Summary

Fix authentication issues discovered during testing:

### Backend Changes (`src/sage/api/auth.py`)
- Add HKDF key derivation matching NextAuth v4's encryption key generation
- Add cookie-based auth fallback for httpOnly session cookies
- Add logging for auth debugging

### Frontend Changes (`web/`)
- Add `/api/ws-token` endpoint to securely read httpOnly session cookie
- Update `getAuthToken()` to use ws-token endpoint instead of direct cookie access
- Fix middleware to exempt all API routes (backend handles its own auth)
- Add exact path rewrites for API routes without path params

## Problem

NextAuth v4 derives JWE encryption keys using HKDF, but the backend was trying to use the raw secret. Additionally, httpOnly cookies can't be read by JavaScript, breaking WebSocket authentication.

## Solution

1. Backend now derives encryption key using HKDF with same parameters as NextAuth v4
2. Backend also checks for session tokens in cookies (not just Authorization header)
3. Frontend uses new `/api/ws-token` endpoint to get token for WebSocket connections

## Test plan
- [x] All 653 tests pass
- [x] JWE token verification works
- [x] Cookie-based auth fallback works