### PR TITLE
Wire SAGEOrchestrator into chat WebSocket

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 2
-max_iterations: 0
-completion_promise: null
-started_at: "2026-01-15T21:14:55Z"
----
-
-Implement ALL remaining issues in Voice/UI Parity epic

--- a/web/.claude/ralph-loop.local.md
+++ b/web/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 1
-max_iterations: 0
-completion_promise: null
-started_at: "2026-01-14T21:44:05Z"
----
-
-Build practice/roleplay mode for SAGE issue


### PR DESCRIPTION
## Summary

Replaces direct `ConversationEngine` usage with `SAGEOrchestrator` in the chat WebSocket handler, enabling dynamic UI generation based on intent and modality.

**Key changes:**
- Add `_create_orchestrator()` factory function to create orchestrator with settings
- Route all messages through `orchestrator.process_input()` instead of `engine.process_turn_streaming()`
- Pass input modality (`CHAT`, `VOICE`, `FORM`) based on message type
- Form submissions use `InputModality.FORM` with `form_id` and `form_data`
- Voice messages use `InputModality.VOICE`
- Text messages use `InputModality.CHAT`

**This enables:**
- Dynamic UI generation based on intent + modality matrix
- Intent extraction for unstructured voice/chat inputs
- Output strategy decisions (TEXT_ONLY, UI_TREE, VOICE_DESCRIPTION, HYBRID)
- Graceful degradation when UI generation fails
- Multi-turn data collection with `pending_data_request` tracking

## Test plan

- [x] All 659 existing tests pass
- [x] Added 6 new tests for orchestrator integration:
  - `test_create_orchestrator_returns_orchestrator`
  - `test_create_orchestrator_has_conversation_engine`
  - `test_modality_routing_chat`
  - `test_modality_routing_voice`
  - `test_modality_routing_form`
  - `test_ws_incoming_message_all_fields`
- [ ] Manual test: Send chat message and verify orchestrator processes it
- [ ] Manual test: Submit form and verify FORM modality routing

Closes #130 (Task 1: Wire Orchestrator into chat.py)