### PR TITLE
feat(#130): Voice-to-form field mapping for modality parity

### DIFF
--- a/src/sage/api/routes/chat.py
+++ b/src/sage/api/routes/chat.py
@@ -117,6 +117,7 @@ def _response_to_dict(response: Union[SAGEResponse, ExtendedSAGEResponse]) -> di
         "ui_tree": None,
         "voice_hints": None,
         "pending_data_request": None,
+        "form_field_updates": None,
         "ui_purpose": None,
         "estimated_interaction_time": None,
         "graph_filter_update": None,
@@ -131,6 +132,10 @@ def _response_to_dict(response: Union[SAGEResponse, ExtendedSAGEResponse]) -> di
     for field in ("ui_purpose", "estimated_interaction_time"):
         if hasattr(response, field):
             result[field] = getattr(response, field)
+
+    # form_field_updates is a plain dict, assign directly
+    if hasattr(response, "form_field_updates") and response.form_field_updates:
+        result["form_field_updates"] = response.form_field_updates
 
     return result
 

--- a/src/sage/dialogue/structured_output.py
+++ b/src/sage/dialogue/structured_output.py
@@ -266,6 +266,7 @@ class ExtendedSAGEResponse(SAGEResponse):
     - ui_tree: Composable UI tree for ad-hoc UI generation
     - voice_hints: TTS optimization hints
     - pending_data_request: State for multi-turn data collection
+    - form_field_updates: Voice-to-form field mapping for visual form filling
 
     The UI Generation Agent creates ui_tree from ~15 primitive
     components, enabling any UI to be generated dynamically.
@@ -284,6 +285,14 @@ class ExtendedSAGEResponse(SAGEResponse):
     # === DATA COLLECTION STATE ===
     pending_data_request: Optional[PendingDataRequest] = Field(
         default=None, description="Incomplete data collection state"
+    )
+
+    # === VOICE-TO-FORM FIELD MAPPING ===
+    form_field_updates: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Extracted values from voice input to update form fields visually. "
+        "Keys are form field IDs, values are the extracted data. "
+        "Frontend should use these to prefill form fields when present.",
     )
 
     # === UI METADATA ===

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -429,3 +429,74 @@ class TestOrchestratorIntegration:
         assert msg.form_id == "check-in"
         assert msg.data == {"key": "value"}
         assert msg.is_voice is True
+
+
+class TestFormFieldUpdates:
+    """Tests for form_field_updates in response serialization."""
+
+    def test_response_to_dict_includes_form_field_updates(self):
+        """Test _response_to_dict includes form_field_updates when present."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import ExtendedSAGEResponse
+        from sage.graph.models import DialogueMode
+
+        response = ExtendedSAGEResponse(
+            message="Got it, 30 minutes.",
+            current_mode=DialogueMode.CHECK_IN,
+            form_field_updates={"timeAvailable": "focused", "energyLevel": 75},
+        )
+
+        result = _response_to_dict(response)
+
+        assert result["form_field_updates"] is not None
+        assert result["form_field_updates"]["timeAvailable"] == "focused"
+        assert result["form_field_updates"]["energyLevel"] == 75
+
+    def test_response_to_dict_no_form_field_updates(self):
+        """Test _response_to_dict handles missing form_field_updates."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import ExtendedSAGEResponse
+        from sage.graph.models import DialogueMode
+
+        response = ExtendedSAGEResponse(
+            message="Hello",
+            current_mode=DialogueMode.CHECK_IN,
+        )
+
+        result = _response_to_dict(response)
+
+        # Should be None when not present
+        assert result["form_field_updates"] is None
+
+    def test_response_to_dict_empty_form_field_updates(self):
+        """Test _response_to_dict handles empty form_field_updates."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import ExtendedSAGEResponse
+        from sage.graph.models import DialogueMode
+
+        response = ExtendedSAGEResponse(
+            message="Hello",
+            current_mode=DialogueMode.CHECK_IN,
+            form_field_updates={},  # Empty dict
+        )
+
+        result = _response_to_dict(response)
+
+        # Empty dict is falsy, so should be None
+        assert result["form_field_updates"] is None
+
+    def test_response_to_dict_sage_response_no_form_field_updates(self):
+        """Test _response_to_dict handles SAGEResponse (no form_field_updates attr)."""
+        from sage.api.routes.chat import _response_to_dict
+        from sage.dialogue.structured_output import SAGEResponse
+        from sage.graph.models import DialogueMode
+
+        response = SAGEResponse(
+            message="Hello",
+            current_mode=DialogueMode.CHECK_IN,
+        )
+
+        result = _response_to_dict(response)
+
+        # SAGEResponse doesn't have form_field_updates, should be None
+        assert result["form_field_updates"] is None


### PR DESCRIPTION
## Summary
- Adds `form_field_updates` field to `ExtendedSAGEResponse` for voice-to-form field mapping
- Orchestrator populates `form_field_updates` when VOICE or HYBRID modality extracts form data
- Frontend can use these values to visually update form fields (enabling voice/UI parity)

Part of #130: Wire Orchestrator into Chat WebSocket for Dynamic UI Generation (Task 2 of 5)

## Changes
- `src/sage/dialogue/structured_output.py`: Add `form_field_updates` field to ExtendedSAGEResponse
- `src/sage/orchestration/orchestrator.py`: Populate `form_field_updates` in `_create_data_request_response` and `_process_with_engine`
- `src/sage/api/routes/chat.py`: Update `_response_to_dict` to serialize `form_field_updates`
- `tests/test_orchestrator.py`: Add 8 tests for voice-to-form field mapping
- `tests/test_api.py`: Add 4 tests for response serialization

## Test plan
- [x] Voice input returns form_field_updates with extracted values
- [x] Form modality does NOT include form_field_updates
- [x] Chat modality does NOT include form_field_updates  
- [x] Hybrid modality includes form_field_updates
- [x] Empty data results in no form_field_updates
- [x] Field names match FORM_SCHEMAS
- [x] Response serialization handles all cases (present, absent, empty)
- [x] All 671 tests pass