### PR TITLE
feat(#130): Frontend voice-to-form visual filling and form submission display

### DIFF
--- a/web/app/chat/page.tsx
+++ b/web/app/chat/page.tsx
@@ -362,6 +362,7 @@ export default function ChatPage(): JSX.Element {
                     mode={message.mode}
                     ui_tree={message.ui_tree}
                     onUISubmit={handleUISubmit}
+                    form_field_updates={message.form_field_updates}
                   />
                 ))}
               </AnimatePresence>

--- a/web/components/chat/MessageBubble.tsx
+++ b/web/components/chat/MessageBubble.tsx
@@ -16,6 +16,8 @@ export interface MessageBubbleProps {
   ui_tree?: UITreeNode;
   /** Callback when UI form is submitted */
   onUISubmit?: (data: Record<string, unknown>) => void;
+  /** Extracted values from voice input to prefill form fields */
+  form_field_updates?: Record<string, unknown>;
 }
 
 const ANIMATION_CONFIG = {
@@ -32,6 +34,7 @@ export function MessageBubble({
   mode,
   ui_tree,
   onUISubmit,
+  form_field_updates,
 }: MessageBubbleProps): JSX.Element {
   const isUser = role === "user";
   const formattedTime = formatTime(timestamp);
@@ -90,7 +93,11 @@ export function MessageBubble({
         {/* Render UI tree for ad-hoc UI generation */}
         {!isUser && ui_tree && (
           <div className="mt-3 pt-3 border-t border-slate-200 dark:border-slate-700">
-            <UITreeForm tree={ui_tree} onSubmit={handleUISubmit} />
+            <UITreeForm
+              tree={ui_tree}
+              onSubmit={handleUISubmit}
+              initialData={form_field_updates}
+            />
           </div>
         )}
 

--- a/web/hooks/useChat.ts
+++ b/web/hooks/useChat.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { createChatConnection, type ChatWebSocket } from "@/lib/websocket";
+import { formatFormDataAsMessage } from "@/lib/utils";
 import type { ChatMessage, DialogueMode, WSCompleteMessage } from "@/types";
 
 interface UseChatOptions {
@@ -45,6 +46,7 @@ export function useChat({ sessionId, enabled = true, onMessage, onError }: UseCh
         mode: response.mode as DialogueMode,
         ui_tree: response.ui_tree ?? undefined,
         pending_data_request: response.pending_data_request ?? undefined,
+        form_field_updates: response.form_field_updates ?? undefined,
       };
 
       setMessages((prev) => [...prev, chatMessage]);
@@ -119,6 +121,14 @@ export function useChat({ sessionId, enabled = true, onMessage, onError }: UseCh
         return;
       }
 
+      // Add a readable user message for form submission (TTS-friendly)
+      const messageContent = formatFormDataAsMessage(formId, data);
+      const userMessage: ChatMessage = {
+        role: "user",
+        content: messageContent,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, userMessage]);
       setIsTyping(true);
       wsRef.current.sendFormSubmission(formId, data);
     },

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -45,6 +45,8 @@ export interface ChatMessage {
   ui_tree?: UITreeNode;
   /** Pending data request for multi-turn collection (assistant messages only) */
   pending_data_request?: PendingDataRequest;
+  /** Extracted values from voice input to update form fields visually (assistant messages only) */
+  form_field_updates?: Record<string, unknown>;
 }
 
 export type DialogueMode =
@@ -210,6 +212,12 @@ export interface WSCompleteMessage {
     ui_purpose: string | null;
     estimated_interaction_time: number | null;
     graph_filter_update: GraphFilterUpdate | null;
+    /**
+     * Extracted values from voice input to update form fields visually.
+     * Keys are form field IDs, values are the extracted data.
+     * Frontend should use these to prefill form fields when present.
+     */
+    form_field_updates: Record<string, unknown> | null;
   };
 }
 


### PR DESCRIPTION
## Summary
- Frontend voice-to-form visual filling: When voice input extracts form field values, they now prefill the form visually
- Form submissions appear as readable user messages in chat feed (TTS-friendly)

## Test plan
- [ ] Voice input while form is displayed fills form fields visually
- [ ] Form submissions show as natural language user messages in chat
- [ ] TypeScript builds without errors
- [ ] All backend tests pass